### PR TITLE
ci: fix connected tests

### DIFF
--- a/.github/scripts/connected-android-test.sh
+++ b/.github/scripts/connected-android-test.sh
@@ -4,27 +4,20 @@ set -euo pipefail
 OUTPUT_ROOT="build/ci-connected-android-test-reports"
 echo "reports-path=$OUTPUT_ROOT" >>"$GITHUB_OUTPUT"
 
-# NOTE: on API 24 the app tests log "additionalTestOutput is not supported
-# on this device running API level 24" — the OCR additional-test-output
-# directory is unavailable on that image. Harmless; tests still pass.
-
 # Keep in sync with the "Build Application" step in
 # .github/workflows/connected-android-test.yml
 TEST_TASKS="app:connectedUnstableDebugAndroidTest core:connectedDebugAndroidTest shared:connectedAndroidDeviceTest"
 
-# Environment-instability signatures seen on older API images (e.g. API 24):
-# the emulator becomes unresponsive mid-APK-install. When a failure matches
-# one of these we retry ONCE after restarting adb. Anything else is treated
-# as a real regression and must not be retried.
+# Environment-instability signatures seen on older API images (e.g. API 24).
+# When a failure matches one of these we retry ONCE after restarting adb.
+# Anything else is treated as a real failure and must not be retried.
 RETRY_SIGNATURES=(
     "ShellCommandUnresponsiveException"
     "InstallException"
     "install-write"
     "device offline"
     "device not found"
-    # Rarer variant of the same stall: the activity fails to launch on a
-    # device that hung mid-install, and Compose tests report it as
-    # "No compose hierarchies found".
+    # This might happen when device hang up or activity launch failed
     "No compose hierarchies found"
 )
 
@@ -64,11 +57,11 @@ run_stage() {
 
     for attempt in 1 2; do
         log="$OUTPUT_ROOT/gradle-$stage-attempt$attempt.log"
-        if ./gradlew $TEST_TASKS --stacktrace 2>&1 | tee "$log"; then
+        if ./gradlew "$TEST_TASKS" --stacktrace 2>&1 | tee "$log"; then
             return 0
         fi
         if [ "$attempt" -eq 1 ] && is_environment_failure "$log"; then
-            echo "⚠️ Environment failure detected (device unresponsive during install?), retrying once"
+            echo "⚠️ Environment failure detected, retrying once"
             dump_failure_diagnostics
             adb kill-server || true
             adb start-server || true
@@ -88,9 +81,8 @@ archive_reports() {
 
     # Every module listed in TEST_TASKS is expected to produce a connected
     # test report dir. A missing/empty one means the gradle run claimed
-    # success without discoverable results — fail loudly instead of
-    # silently uploading an empty artifact (which actually happened before,
-    # see commit ffa831a).
+    # success without discoverable results - fail loudly instead of
+    # silently uploading an empty artifact.
     local module src
     for module in app core shared; do
         src="$module/build/reports/androidTests/connected"
@@ -122,4 +114,4 @@ if [ $TEST_FAILED -ne 0 ]; then
     exit 1
 fi
 
-echo "✅ All UI tests passed."
+echo "✅ All connected tests passed."

--- a/.github/scripts/connected-android-test.sh
+++ b/.github/scripts/connected-android-test.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
+set -euo pipefail
 
 OUTPUT_ROOT="build/ci-connected-android-test-reports"
 echo "reports-path=$OUTPUT_ROOT" >>"$GITHUB_OUTPUT"
+
+# NOTE: on API 24 the app tests log "additionalTestOutput is not supported
+# on this device running API level 24" — the OCR additional-test-output
+# directory is unavailable on that image. Harmless; tests still pass.
+
+# Keep in sync with the "Build Application" step in
+# .github/workflows/connected-android-test.yml
+TEST_TASKS="app:connectedUnstableDebugAndroidTest core:connectedDebugAndroidTest shared:connectedAndroidDeviceTest"
 
 TEST_FAILED=0
 
@@ -17,16 +26,27 @@ archive_reports() {
     local target_dir="$OUTPUT_ROOT/$stage"
 
     echo "=== Archiving $stage test reports ==="
-    mkdir -p "$target_dir/app" "$target_dir/core" "$target_dir/shared"
 
-    cp -r app/build/reports/androidTests/connected/* "$target_dir/app/" 2>/dev/null || true
-    cp -r core/build/reports/androidTests/connected/* "$target_dir/core/" 2>/dev/null || true
-    cp -r shared/build/reports/androidTests/connected/* "$target_dir/shared/" 2>/dev/null || true
+    # Every module listed in TEST_TASKS is expected to produce a connected
+    # test report dir. A missing/empty one means the gradle run claimed
+    # success without discoverable results — fail loudly instead of
+    # silently uploading an empty artifact (which actually happened before,
+    # see commit ffa831a).
+    local module src
+    for module in app core shared; do
+        src="$module/build/reports/androidTests/connected"
+        if [ ! -d "$src" ] || [ -z "$(ls -A "$src")" ]; then
+            echo "❌ No connected test reports found for :$module: (expected at $src)"
+            exit 1
+        fi
+        mkdir -p "$target_dir/$module"
+        cp -r "$src"/* "$target_dir/$module/"
+    done
 }
 
 echo "=== Starting Portrait Tests ==="
 set_orientation 0
-if ! ./gradlew app:connectedUnstableDebugAndroidTest core:connectedDebugAndroidTest shared:connectedAndroidDeviceTest --stacktrace; then
+if ! ./gradlew $TEST_TASKS --stacktrace; then
     echo "❌ Portrait tests failed!"
     TEST_FAILED=1
 fi
@@ -34,7 +54,7 @@ archive_reports "portrait"
 
 echo "=== Starting Landscape Tests ==="
 set_orientation 1
-if ! ./gradlew app:connectedUnstableDebugAndroidTest core:connectedDebugAndroidTest shared:connectedAndroidDeviceTest --stacktrace; then
+if ! ./gradlew $TEST_TASKS --stacktrace; then
     echo "❌ Landscape tests failed!"
     TEST_FAILED=1
 fi

--- a/.github/scripts/connected-android-test.sh
+++ b/.github/scripts/connected-android-test.sh
@@ -26,7 +26,7 @@ archive_reports() {
 
 echo "=== Starting Portrait Tests ==="
 set_orientation 0
-if ! ./gradlew connectedDebugAndroidTest --stacktrace; then
+if ! ./gradlew app:connectedUnstableDebugAndroidTest core:connectedDebugAndroidTest shared:connectedAndroidDeviceTest --stacktrace; then
     echo "❌ Portrait tests failed!"
     TEST_FAILED=1
 fi
@@ -34,7 +34,7 @@ archive_reports "portrait"
 
 echo "=== Starting Landscape Tests ==="
 set_orientation 1
-if ! ./gradlew connectedDebugAndroidTest --stacktrace; then
+if ! ./gradlew app:connectedUnstableDebugAndroidTest core:connectedDebugAndroidTest shared:connectedAndroidDeviceTest --stacktrace; then
     echo "❌ Landscape tests failed!"
     TEST_FAILED=1
 fi

--- a/.github/scripts/connected-android-test.sh
+++ b/.github/scripts/connected-android-test.sh
@@ -22,6 +22,10 @@ RETRY_SIGNATURES=(
     "install-write"
     "device offline"
     "device not found"
+    # Rarer variant of the same stall: the activity fails to launch on a
+    # device that hung mid-install, and Compose tests report it as
+    # "No compose hierarchies found".
+    "No compose hierarchies found"
 )
 
 TEST_FAILED=0

--- a/.github/scripts/connected-android-test.sh
+++ b/.github/scripts/connected-android-test.sh
@@ -6,7 +6,11 @@ echo "reports-path=$OUTPUT_ROOT" >>"$GITHUB_OUTPUT"
 
 # Keep in sync with the "Build Application" step in
 # .github/workflows/connected-android-test.yml
-TEST_TASKS="app:connectedUnstableDebugAndroidTest core:connectedDebugAndroidTest shared:connectedAndroidDeviceTest"
+TEST_TASKS=(
+    "app:connectedUnstableDebugAndroidTest"
+    "core:connectedDebugAndroidTest"
+    "shared:connectedAndroidDeviceTest"
+)
 
 # Environment-instability signatures seen on older API images (e.g. API 24).
 # When a failure matches one of these we retry ONCE after restarting adb.
@@ -57,7 +61,7 @@ run_stage() {
 
     for attempt in 1 2; do
         log="$OUTPUT_ROOT/gradle-$stage-attempt$attempt.log"
-        if ./gradlew "$TEST_TASKS" --stacktrace 2>&1 | tee "$log"; then
+        if ./gradlew "${TEST_TASKS[@]}" --stacktrace 2>&1 | tee "$log"; then
             return 0
         fi
         if [ "$attempt" -eq 1 ] && is_environment_failure "$log"; then

--- a/.github/scripts/connected-android-test.sh
+++ b/.github/scripts/connected-android-test.sh
@@ -12,6 +12,18 @@ echo "reports-path=$OUTPUT_ROOT" >>"$GITHUB_OUTPUT"
 # .github/workflows/connected-android-test.yml
 TEST_TASKS="app:connectedUnstableDebugAndroidTest core:connectedDebugAndroidTest shared:connectedAndroidDeviceTest"
 
+# Environment-instability signatures seen on older API images (e.g. API 24):
+# the emulator becomes unresponsive mid-APK-install. When a failure matches
+# one of these we retry ONCE after restarting adb. Anything else is treated
+# as a real regression and must not be retried.
+RETRY_SIGNATURES=(
+    "ShellCommandUnresponsiveException"
+    "InstallException"
+    "install-write"
+    "device offline"
+    "device not found"
+)
+
 TEST_FAILED=0
 
 set_orientation() {
@@ -19,6 +31,49 @@ set_orientation() {
     local rotation=$1
     adb shell settings put system accelerometer_rotation 0
     adb shell settings put system user_rotation "$rotation"
+}
+
+is_environment_failure() {
+    local log=$1 signature
+    for signature in "${RETRY_SIGNATURES[@]}"; do
+        if grep -q "$signature" "$log"; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+dump_failure_diagnostics() {
+    local out="$OUTPUT_ROOT/diagnostics"
+    mkdir -p "$out"
+    echo "=== Dumping failure diagnostics to $out ==="
+    # The device may be half-dead at this point, so tolerate dump failures.
+    timeout 30 adb logcat -d >"$out/logcat.log" 2>&1 || echo "⚠️ logcat dump failed or timed out"
+    adb devices -l >"$out/devices.txt" 2>&1 || true
+}
+
+run_stage() {
+    local stage=$1 orientation=$2 attempt
+    local log
+    mkdir -p "$OUTPUT_ROOT"
+    set_orientation "$orientation"
+
+    for attempt in 1 2; do
+        log="$OUTPUT_ROOT/gradle-$stage-attempt$attempt.log"
+        if ./gradlew $TEST_TASKS --stacktrace 2>&1 | tee "$log"; then
+            return 0
+        fi
+        if [ "$attempt" -eq 1 ] && is_environment_failure "$log"; then
+            echo "⚠️ Environment failure detected (device unresponsive during install?), retrying once"
+            dump_failure_diagnostics
+            adb kill-server || true
+            adb start-server || true
+            adb wait-for-device || true
+        else
+            return 1
+        fi
+    done
+    return 1
 }
 
 archive_reports() {
@@ -45,16 +100,14 @@ archive_reports() {
 }
 
 echo "=== Starting Portrait Tests ==="
-set_orientation 0
-if ! ./gradlew $TEST_TASKS --stacktrace; then
+if ! run_stage portrait 0; then
     echo "❌ Portrait tests failed!"
     TEST_FAILED=1
 fi
 archive_reports "portrait"
 
 echo "=== Starting Landscape Tests ==="
-set_orientation 1
-if ! ./gradlew $TEST_TASKS --stacktrace; then
+if ! run_stage landscape 1; then
     echo "❌ Landscape tests failed!"
     TEST_FAILED=1
 fi

--- a/.github/scripts/connected-android-test.sh
+++ b/.github/scripts/connected-android-test.sh
@@ -17,9 +17,10 @@ archive_reports() {
     local target_dir="$OUTPUT_ROOT/$stage"
 
     echo "=== Archiving $stage test reports ==="
-    mkdir -p "$target_dir/app" "$target_dir/shared"
+    mkdir -p "$target_dir/app" "$target_dir/core" "$target_dir/shared"
 
     cp -r app/build/reports/androidTests/connected/* "$target_dir/app/" 2>/dev/null || true
+    cp -r core/build/reports/androidTests/connected/* "$target_dir/core/" 2>/dev/null || true
     cp -r shared/build/reports/androidTests/connected/* "$target_dir/shared/" 2>/dev/null || true
 }
 

--- a/.github/workflows/connected-android-test.yml
+++ b/.github/workflows/connected-android-test.yml
@@ -46,7 +46,7 @@ jobs:
 
       # Avoid building the application when AVD is running, so Gradle can use more RAM
       - name: Build Application
-        run: ./gradlew assembleDebugAndroidTest --stacktrace
+        run: ./gradlew app:assembleUnstableDebugAndroidTest core:assembleDebugAndroidTest shared:assembleAndroidDeviceTest --stacktrace
 
       # android-emulator-runner configurations start here
       # See also https://github.com/ReactiveCircus/android-emulator-runner#usage--examples

--- a/.github/workflows/connected-android-test.yml
+++ b/.github/workflows/connected-android-test.yml
@@ -45,6 +45,7 @@ jobs:
         uses: ./.github/actions/setup-ocr-model
 
       # Avoid building the application when AVD is running, so Gradle can use more RAM
+      # NOTE: keep this task list in sync with TEST_TASKS in .github/scripts/connected-android-test.sh
       - name: Build Application
         run: ./gradlew app:assembleUnstableDebugAndroidTest core:assembleDebugAndroidTest shared:assembleAndroidDeviceTest --stacktrace
 

--- a/.github/workflows/connected-android-test.yml
+++ b/.github/workflows/connected-android-test.yml
@@ -73,3 +73,4 @@ jobs:
         with:
           name: test-results-api${{ matrix.api-level }}-${{ matrix.target }}
           path: ${{ steps.ui_tests.outputs.reports-path }}
+          if-no-files-found: error


### PR DESCRIPTION
Fixes the connectedAndroidTest workflow after the KMP migration (222b0d8). Supersedes and closes #49. Also closes #48.

### Background
Since 222b0d8 only `:core:` tests actually ran on CI (the aggregate task name doesn't match the flavored `:app:` or the KMP `:shared:` modules), the artifact was always empty (reports archived from the wrong modules, failures silenced by `\|\| true`), and API 24 jobs failed frequently on emulator install hangs.

### Commits
- **fix connected test report upload losing core module reports** — archive `:core:` reports too, upload with `if-no-files-found: error`
- **run all module connected tests with explicit task names** — `:app:` (unstable flavor), `:core:`, `:shared:` device tests now actually run
- **harden connected test script against silent report loss** — `set -euo pipefail`, fail loudly when expected report dirs are missing, dedupe task list
- **retry once on emulator environment failures with diagnostics** — signature-based retry (adb restart) + per-attempt logs and logcat dump into the artifact

### Verification
API 24 and API 36 both fully green; the retry path was naturally exercised (landscape install hang → retry → pass) with diagnostics present in the artifact.

API level / `default` target intentionally unchanged (minSdk 24, no Google services requirement).