### PR TITLE
Download Resources from the Publish API

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="33" />

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/datastore/AppPreferences.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/datastore/AppPreferences.kt
@@ -5,18 +5,22 @@ import androidx.datastore.core.CorruptionException
 import androidx.datastore.core.okio.OkioSerializer
 import com.akuleshov7.ktoml.Toml
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.map
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import okio.BufferedSink
 import okio.BufferedSource
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
 
 @Serializable
 data class AppPreferences(
     val metadata: PreferencesMetadata = PreferencesMetadata(),
     @SerialName("auto_send_crash_reports")
     val autoSendCrashReports: Boolean = false,
+    @SerialName("resources_api_base_url")
+    val resourcesApiBaseUrl: String = ArcaeaResourcesApiClient.DEFAULT_BASE_URL,
 )
 
 object AppPreferencesSerializer : OkioSerializer<AppPreferences> {
@@ -45,9 +49,18 @@ class AppPreferencesRepository(
     private val dataStore = AppDataStoreProvider.appPreferences(context)
     val preferencesFlow = dataStore.data
 
+    val resourcesApiBaseUrlFlow =
+        preferencesFlow.map { it.resourcesApiBaseUrl }
+
     suspend fun setAutoSendCrashReports(value: Boolean) {
         dataStore.updateData { preferences ->
             preferences.copy(autoSendCrashReports = value)
+        }
+    }
+
+    suspend fun setResourcesApiBaseUrl(value: String) {
+        dataStore.updateData { preferences ->
+            preferences.copy(resourcesApiBaseUrl = value)
         }
     }
 }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/di/AppModule.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/di/AppModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.github.panpf.sketch.Sketch
 import com.github.panpf.sketch.cache.MemoryCache
 import com.github.panpf.sketch.util.Logger
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
 import org.koin.dsl.module
 import org.koin.plugin.module.dsl.bind
 import org.koin.plugin.module.dsl.create
@@ -56,6 +58,15 @@ internal fun createAppDatabase(context: Context): AppDatabase = AppDatabase.getD
 internal fun createArcaeaResourcesApiClient(appPreferencesRepository: AppPreferencesRepository) =
     ArcaeaResourcesApiClient(appPreferencesRepository.resourcesApiBaseUrlFlow)
 
+internal fun createRemoteResourcesInfoStateHolder(
+    resourcesApiClient: ArcaeaResourcesApiClient,
+    appPreferencesRepository: AppPreferencesRepository,
+) = RemoteResourcesInfoStateHolder(
+    resourcesApiClient = resourcesApiClient,
+    // Skip the initial emission: the holder refreshes on construction anyway.
+    baseUrlChanges = appPreferencesRepository.resourcesApiBaseUrlFlow.drop(1).distinctUntilChanged(),
+)
+
 internal fun ocrHistoryDao(db: AppDatabase) = db.ocrHistoryDao()
 
 internal fun createOcrQueueDatabase(context: Context): OcrQueueDatabase = OcrQueueDatabase.getDatabase(context)
@@ -103,7 +114,7 @@ val appModule =
         single<UnstableFlavorPreferencesRepository>()
 
         single<ArcaeaResourcesApiClient> { create(::createArcaeaResourcesApiClient) }
-        single<RemoteResourcesInfoStateHolder>()
+        single<RemoteResourcesInfoStateHolder> { create(::createRemoteResourcesInfoStateHolder) }
 
         viewModel<EmergencyModeActivityViewModel>()
         viewModel<OverviewViewModel>()

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/di/AppModule.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/di/AppModule.kt
@@ -10,6 +10,8 @@ import org.koin.plugin.module.dsl.create
 import org.koin.plugin.module.dsl.single
 import org.koin.plugin.module.dsl.viewModel
 import org.koin.plugin.module.dsl.worker
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
+import xyz.sevive.arcaeaoffline.core.api.RemoteResourcesInfoStateHolder
 import xyz.sevive.arcaeaoffline.core.di.coreModule
 import xyz.sevive.arcaeaoffline.database.AppDatabase
 import xyz.sevive.arcaeaoffline.database.OcrQueueDatabase
@@ -50,6 +52,9 @@ import xyz.sevive.arcaeaoffline.ui.screens.settings.unstablealert.SettingsUnstab
 import xyz.sevive.arcaeaoffline.ui.screens.utilities.UtilitiesChartRecommendScreenViewModel
 
 internal fun createAppDatabase(context: Context): AppDatabase = AppDatabase.getDatabase(context)
+
+internal fun createArcaeaResourcesApiClient(appPreferencesRepository: AppPreferencesRepository) =
+    ArcaeaResourcesApiClient(appPreferencesRepository.resourcesApiBaseUrlFlow)
 
 internal fun ocrHistoryDao(db: AppDatabase) = db.ocrHistoryDao()
 
@@ -96,6 +101,9 @@ val appModule =
         single<EmergencyModePreferencesRepository>()
         single<OcrQueuePreferencesRepository>()
         single<UnstableFlavorPreferencesRepository>()
+
+        single<ArcaeaResourcesApiClient> { create(::createArcaeaResourcesApiClient) }
+        single<RemoteResourcesInfoStateHolder>()
 
         viewModel<EmergencyModeActivityViewModel>()
         viewModel<OverviewViewModel>()

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/helpers/context/Context.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/helpers/context/Context.kt
@@ -13,6 +13,7 @@ import io.github.vinceglb.filekit.source
 import io.github.vinceglb.filekit.utils.div
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
 
 // find activity from context
 // https://stackoverflow.com/a/69235067/16484891
@@ -45,6 +46,19 @@ fun Context.copyToCache(
 }
 
 fun Context.getFileSize(uri: Uri): Long? = runCatching { PlatformFile(uri).size() }.getOrNull()
+
+/**
+ * Returns the file size when it exceeds [limit], null when it is within the limit or when the size
+ * cannot be resolved (an unresolvable size is allowed through, same as the pre-extraction
+ * [Context.getFileSize]-based check). Logging and user feedback are the caller's job.
+ */
+fun Context.uriSizeIfTooLarge(
+    uri: Uri,
+    limit: Long = ArcaeaResourcesApiClient.DEFAULT_MAX_RESOURCE_BYTES,
+): Long? {
+    val fileSize = getFileSize(uri) ?: return null
+    return fileSize.takeIf { it > limit }
+}
 
 fun Context.persistUriPermissions(
     uri: Uri,

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/components/resources/RemoteResourceDownloadItem.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/components/resources/RemoteResourceDownloadItem.kt
@@ -48,7 +48,9 @@ fun RemoteResourceDownloadItem(
 
     TextPreferencesWidget(
         onClick = onDownload,
-        enabled = !infoState.isFetching && !isDownloading && (fileInfo?.isAvailable ?: true),
+        // fileInfo is null only while remote info is unknown (refresh failed or not yet fetched);
+        // downloading on an unprobed path would just 404, so wait for a successful refresh.
+        enabled = !infoState.isFetching && !isDownloading && fileInfo?.isAvailable == true,
         title = title,
         content = contentFor(fileInfo, isDownloading, downloadErrorText, infoState.errorText),
         leadingSlot = {

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/components/resources/RemoteResourceDownloadItem.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/components/resources/RemoteResourceDownloadItem.kt
@@ -41,6 +41,8 @@ fun RemoteResourceDownloadItem(
     onDownload: () -> Unit,
     modifier: Modifier = Modifier,
     isDownloading: Boolean = false,
+    /** Another ih.db writer (manual import) is running; the two flows share the staging file. */
+    isOtherWriteRunning: Boolean = false,
     downloadErrorText: String? = null,
     trailingSlot: (@Composable () -> Unit)? = null,
 ) {
@@ -50,7 +52,7 @@ fun RemoteResourceDownloadItem(
         onClick = onDownload,
         // fileInfo is null only while remote info is unknown (refresh failed or not yet fetched);
         // downloading on an unprobed path would just 404, so wait for a successful refresh.
-        enabled = !infoState.isFetching && !isDownloading && fileInfo?.isAvailable == true,
+        enabled = !infoState.isFetching && !isDownloading && !isOtherWriteRunning && fileInfo?.isAvailable == true,
         title = title,
         content = contentFor(fileInfo, isDownloading, downloadErrorText, infoState.errorText),
         leadingSlot = {

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/components/resources/RemoteResourceDownloadItem.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/components/resources/RemoteResourceDownloadItem.kt
@@ -1,0 +1,60 @@
+package xyz.sevive.arcaeaoffline.ui.components.resources
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import xyz.sevive.arcaeaoffline.R
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesRemoteFileInfo
+import xyz.sevive.arcaeaoffline.core.api.DownloadableResource
+import xyz.sevive.arcaeaoffline.core.api.RemoteResourcesInfoUiState
+import xyz.sevive.arcaeaoffline.ui.components.preferences.TextPreferencesWidget
+
+@Composable
+private fun contentFor(
+    fileInfo: ArcaeaResourcesRemoteFileInfo?,
+    isDownloading: Boolean,
+    downloadErrorText: String?,
+    refreshErrorText: String?,
+): String? =
+    when {
+        isDownloading -> stringResource(R.string.general_downloading)
+
+        downloadErrorText != null -> downloadErrorText
+
+        fileInfo != null -> remoteResourcesFileInfoText(fileInfo)
+
+        // Per-file info is absent only when the whole refresh failed; fall back to its error text.
+        refreshErrorText != null -> refreshErrorText
+
+        else -> null
+    }
+
+@Composable
+fun RemoteResourceDownloadItem(
+    resource: DownloadableResource,
+    infoState: RemoteResourcesInfoUiState,
+    title: String,
+    onDownload: () -> Unit,
+    modifier: Modifier = Modifier,
+    isDownloading: Boolean = false,
+    downloadErrorText: String? = null,
+    trailingSlot: (@Composable () -> Unit)? = null,
+) {
+    val fileInfo = infoState.info?.get(resource)
+
+    TextPreferencesWidget(
+        onClick = onDownload,
+        enabled = !infoState.isFetching && !isDownloading && (fileInfo?.isAvailable ?: true),
+        title = title,
+        content = contentFor(fileInfo, isDownloading, downloadErrorText, infoState.errorText),
+        leadingSlot = {
+            Icon(Icons.Default.CloudDownload, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+        },
+        trailingSlot = trailingSlot,
+        modifier = modifier,
+    )
+}

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/components/resources/RemoteResourcesFileInfoText.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/components/resources/RemoteResourcesFileInfoText.kt
@@ -1,0 +1,27 @@
+package xyz.sevive.arcaeaoffline.ui.components.resources
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.res.stringResource
+import xyz.sevive.arcaeaoffline.R
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesRemoteFileInfo
+import xyz.sevive.arcaeaoffline.helpers.formatAsLocalizedDateTime
+import kotlin.time.Instant
+
+@Composable
+fun remoteResourcesFileInfoText(fileInfo: ArcaeaResourcesRemoteFileInfo?): String? {
+    if (fileInfo == null) return null
+    if (!fileInfo.isAvailable) return fileInfo.errorText ?: stringResource(R.string.general_unknown)
+
+    val builtAtText =
+        remember(fileInfo.builtAt) {
+            fileInfo.builtAt?.let { Instant.fromEpochMilliseconds(it).formatAsLocalizedDateTime() }
+        }?.let { stringResource(R.string.general_updated_at, it) }
+
+    return buildString {
+        append(fileInfo.version ?: stringResource(R.string.general_unknown))
+        append(" (")
+        append(builtAtText ?: stringResource(R.string.general_unknown))
+        append(")")
+    }
+}

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageDownload.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageDownload.kt
@@ -13,6 +13,7 @@ import xyz.sevive.arcaeaoffline.ui.components.resources.RemoteResourceDownloadIt
 fun DatabaseManageDownload(
     remoteResourcesInfoState: RemoteResourcesInfoUiState,
     downloadingResources: Set<DownloadableResource>,
+    downloadErrorTexts: Map<DownloadableResource, String>,
     onDownloadPacklist: () -> Unit,
     onDownloadSonglist: () -> Unit,
     onDownloadChartInfoDatabase: () -> Unit,
@@ -23,6 +24,7 @@ fun DatabaseManageDownload(
             resource = DownloadableResource.PACKLIST,
             infoState = remoteResourcesInfoState,
             isDownloading = DownloadableResource.PACKLIST in downloadingResources,
+            downloadErrorText = downloadErrorTexts[DownloadableResource.PACKLIST],
             title = stringResource(R.string.database_manage_download_packlist),
             onDownload = onDownloadPacklist,
         )
@@ -31,6 +33,7 @@ fun DatabaseManageDownload(
             resource = DownloadableResource.SONGLIST,
             infoState = remoteResourcesInfoState,
             isDownloading = DownloadableResource.SONGLIST in downloadingResources,
+            downloadErrorText = downloadErrorTexts[DownloadableResource.SONGLIST],
             title = stringResource(R.string.database_manage_download_songlist),
             onDownload = onDownloadSonglist,
         )
@@ -39,6 +42,7 @@ fun DatabaseManageDownload(
             resource = DownloadableResource.CHART_INFO_DATABASE,
             infoState = remoteResourcesInfoState,
             isDownloading = DownloadableResource.CHART_INFO_DATABASE in downloadingResources,
+            downloadErrorText = downloadErrorTexts[DownloadableResource.CHART_INFO_DATABASE],
             title = stringResource(R.string.database_manage_download_chart_info_database),
             onDownload = onDownloadChartInfoDatabase,
         )

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageDownload.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageDownload.kt
@@ -1,0 +1,46 @@
+package xyz.sevive.arcaeaoffline.ui.screens.database.manage
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import xyz.sevive.arcaeaoffline.R
+import xyz.sevive.arcaeaoffline.core.api.DownloadableResource
+import xyz.sevive.arcaeaoffline.core.api.RemoteResourcesInfoUiState
+import xyz.sevive.arcaeaoffline.ui.components.resources.RemoteResourceDownloadItem
+
+@Composable
+fun DatabaseManageDownload(
+    remoteResourcesInfoState: RemoteResourcesInfoUiState,
+    downloadingResources: Set<DownloadableResource>,
+    onDownloadPacklist: () -> Unit,
+    onDownloadSonglist: () -> Unit,
+    onDownloadChartInfoDatabase: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier) {
+        RemoteResourceDownloadItem(
+            resource = DownloadableResource.PACKLIST,
+            infoState = remoteResourcesInfoState,
+            isDownloading = DownloadableResource.PACKLIST in downloadingResources,
+            title = stringResource(R.string.database_manage_download_packlist),
+            onDownload = onDownloadPacklist,
+        )
+
+        RemoteResourceDownloadItem(
+            resource = DownloadableResource.SONGLIST,
+            infoState = remoteResourcesInfoState,
+            isDownloading = DownloadableResource.SONGLIST in downloadingResources,
+            title = stringResource(R.string.database_manage_download_songlist),
+            onDownload = onDownloadSonglist,
+        )
+
+        RemoteResourceDownloadItem(
+            resource = DownloadableResource.CHART_INFO_DATABASE,
+            infoState = remoteResourcesInfoState,
+            isDownloading = DownloadableResource.CHART_INFO_DATABASE in downloadingResources,
+            title = stringResource(R.string.database_manage_download_chart_info_database),
+            onDownload = onDownloadChartInfoDatabase,
+        )
+    }
+}

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageScreen.kt
@@ -125,6 +125,7 @@ fun DatabaseManageScreen(
                 DatabaseManageDownload(
                     remoteResourcesInfoState = uiState.remoteResourcesInfoState,
                     downloadingResources = uiState.downloadingResources,
+                    downloadErrorTexts = uiState.downloadErrorTexts,
                     onDownloadPacklist = { viewModel.downloadPacklist() },
                     onDownloadSonglist = { viewModel.downloadSonglist(context) },
                     onDownloadChartInfoDatabase = { viewModel.downloadChartInfoDatabase(context) },

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageScreen.kt
@@ -79,7 +79,7 @@ fun DatabaseManageScreen(
 
             item {
                 DatabaseManageImport(
-                    onImportPacklist = { viewModel.importPacklist(it) },
+                    onImportPacklist = { viewModel.importPacklist(it, context) },
                     onImportSonglist = { viewModel.importSonglist(it, context) },
                     onImportArcaeaApk = { viewModel.importArcaeaApkFromSelected(it, context) },
                     canImportLists = canImportLists,

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageScreen.kt
@@ -2,15 +2,19 @@ package xyz.sevive.arcaeaoffline.ui.screens.database.manage
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Download
 import androidx.compose.material.icons.filled.PendingActions
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Upload
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -21,12 +25,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.sevive.arcaeaoffline.R
 import xyz.sevive.arcaeaoffline.ui.SubScreenContainer
 import xyz.sevive.arcaeaoffline.ui.components.IconRow
 import xyz.sevive.arcaeaoffline.ui.components.ListGroupHeader
+import xyz.sevive.arcaeaoffline.ui.components.preferences.TextPreferencesWidget
 
 @Composable
 fun DatabaseManageScreen(
@@ -80,6 +86,48 @@ fun DatabaseManageScreen(
                     onImportFromInstalledArcaea = { viewModel.importArcaeaApkFromInstalled(context) },
                     onImportChartInfoDatabase = { viewModel.importChartsInfoDatabase(it, context) },
                     onImportSt3 = { viewModel.importSt3(it, context) },
+                    Modifier.fillMaxWidth(),
+                )
+            }
+
+            item { HorizontalDivider() }
+
+            item {
+                ListGroupHeader {
+                    IconRow {
+                        Icon(Icons.Default.CloudDownload, contentDescription = null)
+                        Text(stringResource(R.string.database_manage_download_title))
+                    }
+                }
+            }
+
+            item {
+                val isFetchingRemoteInfo = uiState.remoteResourcesInfoState.isFetching
+                TextPreferencesWidget(
+                    onClick = { viewModel.refreshRemoteResourcesInfo() },
+                    enabled = !isFetchingRemoteInfo,
+                    leadingSlot = {
+                        if (isFetchingRemoteInfo) {
+                            CircularProgressIndicator(Modifier.size(24.dp))
+                        } else {
+                            Icon(
+                                Icons.Default.Refresh,
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    },
+                    title = stringResource(R.string.database_manage_refresh_remote_info),
+                )
+            }
+
+            item {
+                DatabaseManageDownload(
+                    remoteResourcesInfoState = uiState.remoteResourcesInfoState,
+                    downloadingResources = uiState.downloadingResources,
+                    onDownloadPacklist = { viewModel.downloadPacklist() },
+                    onDownloadSonglist = { viewModel.downloadSonglist(context) },
+                    onDownloadChartInfoDatabase = { viewModel.downloadChartInfoDatabase(context) },
                     Modifier.fillMaxWidth(),
                 )
             }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
@@ -440,6 +440,10 @@ class DatabaseManageViewModel(
         logTag: String,
         action: suspend CoroutineScope.() -> Unit,
     ) {
+        // The UI disables the item via recomposition, which lags the click: guard here so a
+        // double tap cannot enqueue the same resource twice.
+        if (resource in downloadingResources.value) return
+
         // Read-modify-write on a dispatcher shared with other downloads: value += is not atomic.
         // Set before dispatching so the item shows "downloading" immediately and a double tap
         // cannot re-enter before the queued task starts.

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
@@ -88,6 +88,7 @@ class DatabaseManageViewModel(
         val logs: List<ImportLogObject> = emptyList(),
         val remoteResourcesInfoState: RemoteResourcesInfoUiState = RemoteResourcesInfoUiState(),
         val downloadingResources: Set<DownloadableResource> = emptySet(),
+        val downloadErrorTexts: Map<DownloadableResource, String> = emptyMap(),
     )
 
     private val logger = Logger.withTag(LOG_TAG)
@@ -102,6 +103,9 @@ class DatabaseManageViewModel(
     /** Resources with a download requested (queued or running); removed when the task settles. */
     private val downloadingResources = MutableStateFlow<Set<DownloadableResource>>(emptySet())
 
+    /** Last failure per downloaded resource; cleared on re-submission so the item can show the error inline. */
+    private val downloadErrorTexts = MutableStateFlow<Map<DownloadableResource, String>>(emptyMap())
+
     fun refreshRemoteResourcesInfo() = remoteResourcesInfoStateHolder.refresh()
 
     internal val uiState =
@@ -110,12 +114,14 @@ class DatabaseManageViewModel(
             importLogManager.logs,
             remoteResourcesInfoStateHolder.state,
             downloadingResources,
-        ) { isWorking, logs, remoteResourcesInfoState, downloadingResources ->
+            downloadErrorTexts,
+        ) { isWorking, logs, remoteResourcesInfoState, downloadingResources, downloadErrorTexts ->
             UiState(
                 isWorking = isWorking,
                 logs = logs.sortedByDescending { it.timestamp },
                 remoteResourcesInfoState = remoteResourcesInfoState,
                 downloadingResources = downloadingResources,
+                downloadErrorTexts = downloadErrorTexts,
             )
         }.stateIn(
             viewModelScope,
@@ -437,6 +443,7 @@ class DatabaseManageViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             // Read-modify-write on a dispatcher shared with other downloads: value += is not atomic.
             downloadingResources.update { it + resource }
+            downloadErrorTexts.update { it - resource }
             sendTask {
                 importLogManager.append(
                     logTag,
@@ -449,6 +456,7 @@ class DatabaseManageViewModel(
                     throw e
                 } catch (e: Exception) {
                     logger.e(e) { "Error downloading $resource" }
+                    downloadErrorTexts.update { it + (resource to throwableToErrorText(e)) }
                     importLogManager.append(logTag, ImportLogEvent.Raw(throwableToErrorText(e)))
                 } finally {
                     downloadingResources.update { it - resource }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
@@ -440,10 +440,12 @@ class DatabaseManageViewModel(
         logTag: String,
         action: suspend CoroutineScope.() -> Unit,
     ) {
+        // Read-modify-write on a dispatcher shared with other downloads: value += is not atomic.
+        // Set before dispatching so the item shows "downloading" immediately and a double tap
+        // cannot re-enter before the queued task starts.
+        downloadingResources.update { it + resource }
+        downloadErrorTexts.update { it - resource }
         viewModelScope.launch(Dispatchers.IO) {
-            // Read-modify-write on a dispatcher shared with other downloads: value += is not atomic.
-            downloadingResources.update { it + resource }
-            downloadErrorTexts.update { it - resource }
             sendTask {
                 importLogManager.append(
                     logTag,

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
@@ -2,6 +2,7 @@ package xyz.sevive.arcaeaoffline.ui.screens.database.manage
 
 import android.content.Context
 import android.net.Uri
+import android.text.format.Formatter
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.sqlite.SQLiteConnection
@@ -45,6 +46,7 @@ import xyz.sevive.arcaeaoffline.core.database.repositories.SongRepository
 import xyz.sevive.arcaeaoffline.helpers.ArcaeaPackageHelper
 import xyz.sevive.arcaeaoffline.helpers.ArcaeaResourcesStateHolder
 import xyz.sevive.arcaeaoffline.helpers.context.copyToCache
+import xyz.sevive.arcaeaoffline.helpers.context.uriSizeIfTooLarge
 import java.io.FileInputStream
 import java.io.InputStream
 import java.io.OutputStream
@@ -127,6 +129,25 @@ class DatabaseManageViewModel(
         taskQueue.send(action)
     }
 
+    /**
+     * Returns true when [uri] exceeds the import size cap, appending a log entry under [logTag];
+     * the caller returns early on true.
+     */
+    private suspend fun Context.importFileTooLarge(
+        uri: Uri,
+        logTag: String,
+    ): Boolean {
+        val actualSize = uriSizeIfTooLarge(uri) ?: return false
+        importLogManager.append(
+            logTag,
+            ImportLogEvent.Raw(
+                "input file too large, limit is ${Formatter.formatFileSize(this, ArcaeaResourcesApiClient.DEFAULT_MAX_RESOURCE_BYTES)} " +
+                    "while input is ${Formatter.formatFileSize(this, actualSize)}!",
+            ),
+        )
+        return true
+    }
+
     private suspend fun importPacklistTask(packlistContent: String) {
         val importer = ArcaeaPacklistImporter(packlistContent)
 
@@ -148,9 +169,14 @@ class DatabaseManageViewModel(
         )
     }
 
-    fun importPacklist(uri: Uri) {
+    fun importPacklist(
+        uri: Uri,
+        context: Context,
+    ) {
         viewModelScope.launch(Dispatchers.IO) {
             sendTask {
+                if (context.importFileTooLarge(uri, LOG_TAG_IMPORT_PACKLIST)) return@sendTask
+
                 val packlistContent = PlatformFile(uri).readBytes().decodeToString()
                 importPacklistTask(packlistContent)
             }
@@ -226,6 +252,8 @@ class DatabaseManageViewModel(
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             sendTask {
+                if (context.importFileTooLarge(uri, LOG_TAG_IMPORT_SONGLIST)) return@sendTask
+
                 val songlistContent = PlatformFile(uri).readBytes().decodeToString()
                 val supplementSonglistContent = context.assets.open("songlist.json").use { it.readText() }
                 importSonglistTask(songlistContent, supplementSonglistContent)
@@ -327,6 +355,8 @@ class DatabaseManageViewModel(
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             sendTask {
+                if (context.importFileTooLarge(fileUri, LOG_TAG_IMPORT_CHART_INFO_DATABASE)) return@sendTask
+
                 val databaseCopied =
                     context.copyToCache(fileUri, "chart_info_database_copy.db") ?: return@sendTask
 
@@ -356,6 +386,8 @@ class DatabaseManageViewModel(
     ) {
         viewModelScope.launch(Dispatchers.IO) {
             sendTask {
+                if (context.importFileTooLarge(fileUri, LOG_TAG_IMPORT_ST3)) return@sendTask
+
                 val dbCacheFile = context.copyToCache(fileUri, "st3-import-temp") ?: return@sendTask
 
                 BundledSQLiteDriver()

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/DatabaseManageViewModel.kt
@@ -10,20 +10,25 @@ import androidx.sqlite.driver.bundled.SQLITE_OPEN_READONLY
 import co.touchlab.kermit.Logger
 import io.github.vinceglb.filekit.PlatformFile
 import io.github.vinceglb.filekit.readBytes
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.channels.Channel
-import kotlinx.coroutines.channels.consumeEach
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import org.apache.commons.compress.archivers.zip.ZipFile
 import xyz.sevive.arcaeaoffline.R
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
+import xyz.sevive.arcaeaoffline.core.api.DownloadableResource
+import xyz.sevive.arcaeaoffline.core.api.RemoteResourcesInfoStateHolder
+import xyz.sevive.arcaeaoffline.core.api.RemoteResourcesInfoUiState
+import xyz.sevive.arcaeaoffline.core.api.throwableToErrorText
 import xyz.sevive.arcaeaoffline.core.database.externals.exporters.ArcaeaOfflineDEFv2Exporter
 import xyz.sevive.arcaeaoffline.core.database.externals.importers.ArcaeaPacklistImporter
 import xyz.sevive.arcaeaoffline.core.database.externals.importers.ArcaeaSonglistImporter
@@ -46,7 +51,6 @@ import java.io.OutputStream
 import java.nio.charset.Charset
 import java.nio.charset.StandardCharsets
 import kotlin.time.Duration.Companion.seconds
-import kotlin.uuid.Uuid
 
 class DatabaseManageViewModel(
     private val packRepo: PackRepository,
@@ -57,6 +61,8 @@ class DatabaseManageViewModel(
     private val difficultyLocalizedRepo: DifficultyLocalizedRepository,
     private val chartInfoRepo: ChartInfoRepository,
     private val playResultRepo: PlayResultRepository,
+    private val resourcesApiClient: ArcaeaResourcesApiClient,
+    private val remoteResourcesInfoStateHolder: RemoteResourcesInfoStateHolder,
 ) : ViewModel() {
     companion object {
         private const val LOG_TAG = "DatabaseManageVM"
@@ -68,6 +74,9 @@ class DatabaseManageViewModel(
         private const val LOG_TAG_IMPORT_CHART_INFO_DATABASE = "I-CIDb"
         private const val LOG_TAG_IMPORT_ST3 = "I-St3"
         private const val LOG_TAG_EXPORT_PLAY_RESULTS = "E-PR"
+        private const val LOG_TAG_DOWNLOAD_PACKLIST = "D-Pklst"
+        private const val LOG_TAG_DOWNLOAD_SONGLIST = "D-Slst"
+        private const val LOG_TAG_DOWNLOAD_CHART_INFO_DATABASE = "D-CIDb"
     }
 
     private val importLogManager = ImportLogManager()
@@ -75,45 +84,37 @@ class DatabaseManageViewModel(
     internal data class UiState(
         val isWorking: Boolean = false,
         val logs: List<ImportLogObject> = emptyList(),
-    )
-
-    data class Task(
-        val uuid: Uuid = Uuid.generateV4(),
-        val action: suspend CoroutineScope.() -> Unit,
+        val remoteResourcesInfoState: RemoteResourcesInfoUiState = RemoteResourcesInfoUiState(),
+        val downloadingResources: Set<DownloadableResource> = emptySet(),
     )
 
     private val logger = Logger.withTag(LOG_TAG)
 
-    private val taskChannelActive = MutableStateFlow(false)
-    private val taskScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    private val taskQueue =
+        ImportTaskQueue(
+            parentScope = viewModelScope,
+            importLogManager = importLogManager,
+            logger = logger,
+        )
 
-    private val taskChannel = Channel<Task>(Channel.UNLIMITED)
+    /** Resources with a download requested (queued or running); removed when the task settles. */
+    private val downloadingResources = MutableStateFlow<Set<DownloadableResource>>(emptySet())
 
-    init {
-        viewModelScope.launch(Dispatchers.Default) {
-            taskChannel.consumeEach {
-                taskChannelActive.value = true
-                logger.d { "Processing task ${it.uuid}" }
-                taskScope
-                    .launch {
-                        try {
-                            it.action(this)
-                        } catch (e: Throwable) {
-                            logger.e(e) { "Error processing task ${it.uuid}" }
-                            importLogManager.append(
-                                tag = null,
-                                event = ImportLogEvent.Raw(e.toString()),
-                            )
-                        }
-                    }.join()
-                taskChannelActive.value = false
-            }
-        }
-    }
+    fun refreshRemoteResourcesInfo() = remoteResourcesInfoStateHolder.refresh()
 
     internal val uiState =
-        combine(taskChannelActive, importLogManager.logs) { isWorking, logs ->
-            UiState(isWorking = isWorking, logs = logs.sortedByDescending { it.timestamp })
+        combine(
+            taskQueue.isWorking,
+            importLogManager.logs,
+            remoteResourcesInfoStateHolder.state,
+            downloadingResources,
+        ) { isWorking, logs, remoteResourcesInfoState, downloadingResources ->
+            UiState(
+                isWorking = isWorking,
+                logs = logs.sortedByDescending { it.timestamp },
+                remoteResourcesInfoState = remoteResourcesInfoState,
+                downloadingResources = downloadingResources,
+            )
         }.stateIn(
             viewModelScope,
             SharingStarted.WhileSubscribed(5.seconds.inWholeMilliseconds),
@@ -123,10 +124,7 @@ class DatabaseManageViewModel(
     private fun InputStream.readText(charset: Charset = StandardCharsets.UTF_8): String = bufferedReader(charset).use { it.readText() }
 
     private suspend fun sendTask(action: suspend CoroutineScope.() -> Unit) {
-        Task(action = action).let {
-            taskChannel.send(it)
-            logger.d { "Task ${it.uuid} sent" }
-        }
+        taskQueue.send(action)
     }
 
     private suspend fun importPacklistTask(packlistContent: String) {
@@ -389,6 +387,71 @@ class DatabaseManageViewModel(
             sendTask {
                 context.contentResolver.openOutputStream(uri)?.use {
                     exportPlayResults(it)
+                }
+            }
+        }
+    }
+
+    /**
+     * Queues a download task: marks the resource busy from submission (so the item
+     * shows "downloading" and stays disabled while queued or running), and logs
+     * start and failure under [logTag] so errors stay associated with their entry.
+     */
+    private fun enqueueDownloadTask(
+        resource: DownloadableResource,
+        logTag: String,
+        action: suspend CoroutineScope.() -> Unit,
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            // Read-modify-write on a dispatcher shared with other downloads: value += is not atomic.
+            downloadingResources.update { it + resource }
+            sendTask {
+                importLogManager.append(
+                    logTag,
+                    ImportLogEvent.SimpleString(R.string.database_manage_download_started),
+                )
+
+                try {
+                    action()
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    logger.e(e) { "Error downloading $resource" }
+                    importLogManager.append(logTag, ImportLogEvent.Raw(throwableToErrorText(e)))
+                } finally {
+                    downloadingResources.update { it - resource }
+                }
+            }
+        }
+    }
+
+    fun downloadPacklist() {
+        enqueueDownloadTask(DownloadableResource.PACKLIST, LOG_TAG_DOWNLOAD_PACKLIST) {
+            importPacklistTask(resourcesApiClient.packlist())
+        }
+    }
+
+    fun downloadSonglist(context: Context) {
+        enqueueDownloadTask(DownloadableResource.SONGLIST, LOG_TAG_DOWNLOAD_SONGLIST) {
+            val supplementSonglistContent = context.assets.open("songlist.json").use { it.readText() }
+            val songlistContent = resourcesApiClient.songlist()
+            importSonglistTask(songlistContent, supplementSonglistContent)
+        }
+    }
+
+    fun downloadChartInfoDatabase(context: Context) {
+        enqueueDownloadTask(DownloadableResource.CHART_INFO_DATABASE, LOG_TAG_DOWNLOAD_CHART_INFO_DATABASE) {
+            val dest = Path(context.cacheDir.resolve("chart_info_database_download.db").absolutePath)
+            try {
+                resourcesApiClient.downloadChartInfoDatabase(dest)
+
+                BundledSQLiteDriver()
+                    .open(dest.toString(), SQLITE_OPEN_READONLY)
+                    .use { conn -> importChartsInfoDatabase(conn) }
+            } finally {
+                // The download may not have created dest; deleting a missing file throws and masks the real error.
+                if (SystemFileSystem.metadataOrNull(dest) != null) {
+                    SystemFileSystem.delete(dest)
                 }
             }
         }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/ImportTaskQueue.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/ImportTaskQueue.kt
@@ -1,0 +1,67 @@
+package xyz.sevive.arcaeaoffline.ui.screens.database.manage
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlin.uuid.Uuid
+
+/**
+ * Serial task queue: tasks run one at a time in submission order, never concurrently.
+ *
+ * Any [Throwable] thrown inside a task is caught and written to [ImportLogManager]; the queue
+ * keeps processing later tasks. [taskScope] is a child of [parentScope]'s Job, so cancelling
+ * parentScope (e.g. ViewModel destruction) cancels both queued and running tasks.
+ */
+internal class ImportTaskQueue(
+    parentScope: CoroutineScope,
+    private val importLogManager: ImportLogManager,
+    private val logger: Logger,
+) {
+    private data class Task(
+        val uuid: Uuid = Uuid.generateV4(),
+        val action: suspend CoroutineScope.() -> Unit,
+    )
+
+    private val taskScope =
+        CoroutineScope(SupervisorJob(parentScope.coroutineContext[Job]!!) + Dispatchers.IO)
+    private val taskChannel = Channel<Task>(Channel.UNLIMITED)
+
+    private val _isWorking = MutableStateFlow(false)
+    val isWorking: StateFlow<Boolean> = _isWorking.asStateFlow()
+
+    init {
+        parentScope.launch(Dispatchers.Default) {
+            taskChannel.consumeEach { task ->
+                _isWorking.value = true
+                logger.d { "Processing task ${task.uuid}" }
+                taskScope
+                    .launch {
+                        try {
+                            task.action(this)
+                        } catch (e: Throwable) {
+                            logger.e(e) { "Error processing task ${task.uuid}" }
+                            importLogManager.append(
+                                tag = null,
+                                event = ImportLogEvent.Raw(e.toString()),
+                            )
+                        }
+                    }.join()
+                _isWorking.value = false
+            }
+        }
+    }
+
+    suspend fun send(action: suspend CoroutineScope.() -> Unit) {
+        val task = Task(action = action)
+        taskChannel.send(task)
+        logger.d { "Task ${task.uuid} sent" }
+    }
+}

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/ImportTaskQueue.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/ImportTaskQueue.kt
@@ -1,6 +1,7 @@
 package xyz.sevive.arcaeaoffline.ui.screens.database.manage
 
 import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -17,7 +18,8 @@ import kotlin.uuid.Uuid
 /**
  * Serial task queue: tasks run one at a time in submission order, never concurrently.
  *
- * Any [Throwable] thrown inside a task is caught and written to [ImportLogManager]; the queue
+ * Any [Throwable] thrown inside a task is caught and written to [ImportLogManager] (except
+ * [CancellationException], which is rethrown: cancellation is not a task failure); the queue
  * keeps processing later tasks. [taskScope] is a child of [parentScope]'s Job, so cancelling
  * parentScope (e.g. ViewModel destruction) cancels both queued and running tasks.
  */
@@ -52,6 +54,10 @@ internal class ImportTaskQueue(
                     .launch {
                         try {
                             task.action(this)
+                        } catch (e: CancellationException) {
+                            // Rethrow: the append below would itself throw on the cancelled coroutine,
+                            // and cancellation must not be logged as a task failure.
+                            throw e
                         } catch (e: Throwable) {
                             logger.e(e) { "Error processing task ${task.uuid}" }
                             importLogManager.append(

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/ImportTaskQueue.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/database/manage/ImportTaskQueue.kt
@@ -7,9 +7,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.uuid.Uuid
 
@@ -30,17 +31,22 @@ internal class ImportTaskQueue(
         val action: suspend CoroutineScope.() -> Unit,
     )
 
+    // Consumer and tasks anchor to parentScope's Job: cancelling parentScope cancels queued and running tasks.
+    private val parentJob =
+        checkNotNull(parentScope.coroutineContext[Job]) { "parentScope must carry a Job in its context" }
+
     private val taskScope =
-        CoroutineScope(SupervisorJob(parentScope.coroutineContext[Job]!!) + Dispatchers.IO)
+        CoroutineScope(SupervisorJob(parentJob) + Dispatchers.IO)
     private val taskChannel = Channel<Task>(Channel.UNLIMITED)
 
-    private val _isWorking = MutableStateFlow(false)
-    val isWorking: StateFlow<Boolean> = _isWorking.asStateFlow()
+    private val pendingTaskCount = MutableStateFlow(0)
+
+    /** True from the moment a task is submitted until it settles, so the UI never flickers between queued tasks. */
+    val isWorking: Flow<Boolean> = pendingTaskCount.map { it > 0 }
 
     init {
         parentScope.launch(Dispatchers.Default) {
             taskChannel.consumeEach { task ->
-                _isWorking.value = true
                 logger.d { "Processing task ${task.uuid}" }
                 taskScope
                     .launch {
@@ -54,12 +60,13 @@ internal class ImportTaskQueue(
                             )
                         }
                     }.join()
-                _isWorking.value = false
+                pendingTaskCount.update { it - 1 }
             }
         }
     }
 
     suspend fun send(action: suspend CoroutineScope.() -> Unit) {
+        pendingTaskCount.update { it + 1 }
         val task = Task(action = action)
         taskChannel.send(task)
         logger.d { "Task ${task.uuid} sent" }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreen.kt
@@ -61,7 +61,12 @@ fun OcrDependenciesScreen(
             }
 
             item {
+                val importRunning by viewModel.imageHashesDatabaseImportRunning.collectAsStateWithLifecycle()
+                val remoteDownloadUiState by
+                    viewModel.imageHashesDatabaseRemoteDownloadUiState.collectAsStateWithLifecycle()
+
                 TextPreferencesWidget(
+                    enabled = !importRunning && !remoteDownloadUiState.isWorking,
                     onClick = { imageHashesDatabaseFileChooserLauncher.launch("*/*") },
                     leadingIcon = Icons.Default.FileOpen,
                     title = stringResource(R.string.general_import),
@@ -72,11 +77,13 @@ fun OcrDependenciesScreen(
                 val remoteInfoState by viewModel.remoteResourcesInfoState.collectAsStateWithLifecycle()
                 val remoteDownloadUiState by
                     viewModel.imageHashesDatabaseRemoteDownloadUiState.collectAsStateWithLifecycle()
+                val importRunning by viewModel.imageHashesDatabaseImportRunning.collectAsStateWithLifecycle()
 
                 RemoteResourceDownloadItem(
                     resource = DownloadableResource.IMAGE_HASHES_DATABASE,
                     infoState = remoteInfoState,
                     isDownloading = remoteDownloadUiState.isWorking,
+                    isOtherWriteRunning = importRunning,
                     downloadErrorText = remoteDownloadUiState.error,
                     title = stringResource(R.string.ocr_dependencies_download_from_network),
                     onDownload = { viewModel.requestImageHashesDatabaseDownload() },

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreen.kt
@@ -1,9 +1,11 @@
 package xyz.sevive.arcaeaoffline.ui.screens.ocr.dependencies
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FileOpen
 import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -12,9 +14,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import org.koin.compose.viewmodel.koinViewModel
 import xyz.sevive.arcaeaoffline.R
+import xyz.sevive.arcaeaoffline.core.api.DownloadableResource
 import xyz.sevive.arcaeaoffline.helpers.ArcaeaResourcesStateHolder
 import xyz.sevive.arcaeaoffline.helpers.rememberFileChooserLauncher
 import xyz.sevive.arcaeaoffline.ui.SubScreenContainer
@@ -22,6 +26,7 @@ import xyz.sevive.arcaeaoffline.ui.components.ArcaeaAppIcon
 import xyz.sevive.arcaeaoffline.ui.components.ocr.OcrDependencyCrnnModelStatusViewer
 import xyz.sevive.arcaeaoffline.ui.components.ocr.OcrDependencyImageHashesDatabaseStatusViewer
 import xyz.sevive.arcaeaoffline.ui.components.preferences.TextPreferencesWidget
+import xyz.sevive.arcaeaoffline.ui.components.resources.RemoteResourceDownloadItem
 import xyz.sevive.arcaeaoffline.ui.navigation.OcrSubScreen
 
 @Composable
@@ -60,6 +65,30 @@ fun OcrDependenciesScreen(
                     onClick = { imageHashesDatabaseFileChooserLauncher.launch("*/*") },
                     leadingIcon = Icons.Default.FileOpen,
                     title = stringResource(R.string.general_import),
+                )
+            }
+
+            item {
+                val remoteInfoState by viewModel.remoteResourcesInfoState.collectAsStateWithLifecycle()
+                val remoteDownloadUiState by
+                    viewModel.imageHashesDatabaseRemoteDownloadUiState.collectAsStateWithLifecycle()
+
+                RemoteResourceDownloadItem(
+                    resource = DownloadableResource.IMAGE_HASHES_DATABASE,
+                    infoState = remoteInfoState,
+                    isDownloading = remoteDownloadUiState.isWorking,
+                    downloadErrorText = remoteDownloadUiState.error,
+                    title = stringResource(R.string.ocr_dependencies_download_from_network),
+                    onDownload = { viewModel.requestImageHashesDatabaseDownload() },
+                    trailingSlot = {
+                        if (remoteInfoState.isFetching) {
+                            CircularProgressIndicator(Modifier.size(24.dp))
+                        } else {
+                            IconButton(onClick = { viewModel.refreshRemoteResourcesInfo() }) {
+                                Icon(Icons.Default.Refresh, contentDescription = null)
+                            }
+                        }
+                    },
                 )
             }
 

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
@@ -22,6 +22,7 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.io.buffered
+import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import xyz.sevive.arcaeaoffline.core.Progress
 import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
@@ -39,6 +40,7 @@ import xyz.sevive.arcaeaoffline.helpers.fromWorkInfo
 import xyz.sevive.arcaeaoffline.jobs.ImageHashesDatabaseBuilderJob
 import xyz.sevive.arcaeaoffline.ui.components.ocr.OcrDependencyCrnnModelStatusUiState
 import xyz.sevive.arcaeaoffline.ui.components.ocr.OcrDependencyImageHashesDatabaseStatusUiState
+import java.io.File
 import java.io.IOException
 
 /**
@@ -139,9 +141,9 @@ class OcrDependenciesScreenViewModel(
                     ImageHashesDatabase(sqliteDb)
                 }
 
-                // atomicMove replaces an existing destination (REPLACE_EXISTING), so no pre-delete
-                // is needed - a pre-delete would leave ih.db missing if the process died in between.
-                SystemFileSystem.atomicMove(stagingPath, paths.imageHashesDatabaseFile)
+                // Atomic replace, no pre-delete: a pre-delete would leave ih.db missing if the
+                // process died in between.
+                atomicReplace(stagingPath, paths.imageHashesDatabaseFile)
 
                 _imageHashesDatabaseRemoteDownloadUiState.value =
                     ImageHashesDatabaseRemoteDownloadUiState()
@@ -156,6 +158,26 @@ class OcrDependenciesScreenViewModel(
                 if (SystemFileSystem.metadataOrNull(stagingPath) != null) {
                     SystemFileSystem.delete(stagingPath)
                 }
+            }
+        }
+    }
+
+    /**
+     * Atomically replaces [target] with [source]; both paths must be on the same filesystem.
+     *
+     * java.nio.file needs API 26+ and cannot be desugared (kotlinx-io probes it via reflection),
+     * so on API 24/25 [SystemFileSystem.atomicMove] always throws UnsupportedOperationException.
+     * File.renameTo maps to rename(2) on Android: atomic, and it replaces an existing target.
+     */
+    private fun atomicReplace(
+        source: Path,
+        target: Path,
+    ) {
+        try {
+            SystemFileSystem.atomicMove(source, target)
+        } catch (e: UnsupportedOperationException) {
+            if (!File(source.toString()).renameTo(File(target.toString()))) {
+                throw IOException("renameTo failed for $source -> $target")
             }
         }
     }
@@ -209,9 +231,9 @@ class OcrDependenciesScreenViewModel(
                         }
                     }
 
-                    // atomicMove replaces an existing destination (REPLACE_EXISTING), so no pre-delete
-                    // is needed - a pre-delete would leave ih.db missing if the process died in between.
-                    SystemFileSystem.atomicMove(stagingPath, paths.imageHashesDatabaseFile)
+                    // Atomic replace, no pre-delete: a pre-delete would leave ih.db missing if the
+                    // process died in between.
+                    atomicReplace(stagingPath, paths.imageHashesDatabaseFile)
                 } catch (e: Exception) {
                     if (e is SQLiteException) {
                         logger.w(e) { "Input file doesn't seem like to be a SQLite database" }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
@@ -103,6 +103,10 @@ class OcrDependenciesScreenViewModel(
     val imageHashesDatabaseRemoteDownloadUiState =
         _imageHashesDatabaseRemoteDownloadUiState.asStateFlow()
 
+    /** True while a manual ih.db import runs; both import and download write the same files. */
+    private val _imageHashesDatabaseImportRunning = MutableStateFlow(false)
+    val imageHashesDatabaseImportRunning = _imageHashesDatabaseImportRunning.asStateFlow()
+
     init {
         reloadAll(context)
     }
@@ -112,6 +116,7 @@ class OcrDependenciesScreenViewModel(
     /** Downloads ih.db into cache, validates it the same way as manual import, then swaps it into place. */
     fun requestImageHashesDatabaseDownload() {
         if (_imageHashesDatabaseRemoteDownloadUiState.value.isWorking) return
+        if (_imageHashesDatabaseImportRunning.value) return
 
         viewModelScope.launch(Dispatchers.IO) {
             _imageHashesDatabaseRemoteDownloadUiState.value =
@@ -134,10 +139,8 @@ class OcrDependenciesScreenViewModel(
                     ImageHashesDatabase(sqliteDb)
                 }
 
-                // atomicMove does not overwrite; remove the current file first.
-                if (SystemFileSystem.metadataOrNull(paths.imageHashesDatabaseFile) != null) {
-                    SystemFileSystem.delete(paths.imageHashesDatabaseFile)
-                }
+                // atomicMove replaces an existing destination (REPLACE_EXISTING), so no pre-delete
+                // is needed - a pre-delete would leave ih.db missing if the process died in between.
                 SystemFileSystem.atomicMove(stagingPath, paths.imageHashesDatabaseFile)
 
                 _imageHashesDatabaseRemoteDownloadUiState.value =
@@ -190,48 +193,54 @@ class OcrDependenciesScreenViewModel(
         uri: Uri,
         context: Context,
     ) {
+        if (_imageHashesDatabaseRemoteDownloadUiState.value.isWorking) return
+        if (_imageHashesDatabaseImportRunning.value) return
+
         val paths = OcrDependencyPaths()
         if (!mkOcrDependencyParentDirs(paths)) return
 
         viewModelScope.launch(Dispatchers.IO) {
-            if (isFileTooLarge(uri, context, logName = "ImageHashesDatabase")) return@launch
-
-            val cacheFile = context.copyToCache(uri, "image_hashes_db_import_temp") ?: return@launch
-            // Staged next to the destination so the final move stays on one filesystem.
-            val stagingPath = paths.parentDir / "image-hashes.db.staging"
+            _imageHashesDatabaseImportRunning.value = true
             try {
-                // test if the input is a valid database
-                OcrDependencyLoader.imageHashesSQLiteDatabase(cacheFile).use { sqliteDb ->
-                    ImageHashesDatabase(sqliteDb)
-                }
+                if (isFileTooLarge(uri, context, logName = "ImageHashesDatabase")) return@launch
 
-                // Copy to a staging file first: an interrupted direct copy would truncate the current ih.db.
-                SystemFileSystem.source(cacheFile).buffered().use { src ->
-                    SystemFileSystem.sink(stagingPath).buffered().use { dst ->
-                        src.transferTo(dst)
+                val cacheFile = context.copyToCache(uri, "image_hashes_db_import_temp") ?: return@launch
+                // Staged next to the destination so the final move stays on one filesystem.
+                val stagingPath = paths.parentDir / "image-hashes.db.staging"
+                try {
+                    // test if the input is a valid database
+                    OcrDependencyLoader.imageHashesSQLiteDatabase(cacheFile).use { sqliteDb ->
+                        ImageHashesDatabase(sqliteDb)
+                    }
+
+                    // Copy to a staging file first: an interrupted direct copy would truncate the current ih.db.
+                    SystemFileSystem.source(cacheFile).buffered().use { src ->
+                        SystemFileSystem.sink(stagingPath).buffered().use { dst ->
+                            src.transferTo(dst)
+                        }
+                    }
+
+                    // atomicMove replaces an existing destination (REPLACE_EXISTING), so no pre-delete
+                    // is needed - a pre-delete would leave ih.db missing if the process died in between.
+                    SystemFileSystem.atomicMove(stagingPath, paths.imageHashesDatabaseFile)
+                } catch (e: Exception) {
+                    if (e is SQLiteException) {
+                        logger.w(e) { "Input file doesn't seem like to be a SQLite database" }
+                    } else {
+                        logger.e(e) { "Error importing image hashes database" }
+                    }
+                } finally {
+                    for (path in listOf(cacheFile, stagingPath)) {
+                        if (SystemFileSystem.metadataOrNull(path) != null) {
+                            SystemFileSystem.delete(path)
+                        }
                     }
                 }
 
-                // atomicMove does not overwrite; remove the current file first.
-                if (SystemFileSystem.metadataOrNull(paths.imageHashesDatabaseFile) != null) {
-                    SystemFileSystem.delete(paths.imageHashesDatabaseFile)
-                }
-                SystemFileSystem.atomicMove(stagingPath, paths.imageHashesDatabaseFile)
-            } catch (e: Exception) {
-                if (e is SQLiteException) {
-                    logger.w(e) { "Input file doesn't seem like to be a SQLite database" }
-                } else {
-                    logger.e(e) { "Error importing image hashes database" }
-                }
+                reloadImageHashesDatabaseStatusDetailUiState()
             } finally {
-                for (path in listOf(cacheFile, stagingPath)) {
-                    if (SystemFileSystem.metadataOrNull(path) != null) {
-                        SystemFileSystem.delete(path)
-                    }
-                }
+                _imageHashesDatabaseImportRunning.value = false
             }
-
-            reloadImageHashesDatabaseStatusDetailUiState()
         }
     }
 

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
@@ -11,6 +11,8 @@ import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkInfo
 import androidx.work.WorkManager
 import co.touchlab.kermit.Logger
+import io.github.vinceglb.filekit.utils.div
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -20,8 +22,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.io.buffered
+import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import xyz.sevive.arcaeaoffline.core.Progress
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
+import xyz.sevive.arcaeaoffline.core.api.RemoteResourcesInfoStateHolder
+import xyz.sevive.arcaeaoffline.core.api.throwableToErrorText
 import xyz.sevive.arcaeaoffline.core.ocr.ImageHashesDatabase
 import xyz.sevive.arcaeaoffline.data.OcrDependencyPaths
 import xyz.sevive.arcaeaoffline.helpers.ArcaeaResourcesStateHolder
@@ -37,7 +43,9 @@ import xyz.sevive.arcaeaoffline.ui.components.ocr.OcrDependencyImageHashesDataba
 import java.io.IOException
 
 class OcrDependenciesScreenViewModel(
-    context: Context,
+    private val context: Context,
+    private val resourcesApiClient: ArcaeaResourcesApiClient,
+    private val remoteResourcesInfoStateHolder: RemoteResourcesInfoStateHolder,
 ) : ViewModel() {
     companion object {
         private const val STOP_TIME_MILLIS = 5000L
@@ -79,8 +87,82 @@ class OcrDependenciesScreenViewModel(
     private val _crnnModelUiState = MutableStateFlow(OcrDependencyCrnnModelStatusUiState())
     val crnnModelUiState = _crnnModelUiState.asStateFlow()
 
+    /** Remote metadata of the published directory containing ih.db; items are disabled with an indicator while isFetching. */
+    val remoteResourcesInfoState = remoteResourcesInfoStateHolder.state
+
+    data class ImageHashesDatabaseRemoteDownloadUiState(
+        val isWorking: Boolean = false,
+        val error: String? = null,
+    )
+
+    private val _imageHashesDatabaseRemoteDownloadUiState =
+        MutableStateFlow(ImageHashesDatabaseRemoteDownloadUiState())
+    val imageHashesDatabaseRemoteDownloadUiState =
+        _imageHashesDatabaseRemoteDownloadUiState.asStateFlow()
+
     init {
         reloadAll(context)
+    }
+
+    fun refreshRemoteResourcesInfo() = remoteResourcesInfoStateHolder.refresh()
+
+    /** Downloads ih.db into cache, validates it the same way as manual import, then swaps it into place. */
+    fun requestImageHashesDatabaseDownload() {
+        if (_imageHashesDatabaseRemoteDownloadUiState.value.isWorking) return
+
+        viewModelScope.launch(Dispatchers.IO) {
+            _imageHashesDatabaseRemoteDownloadUiState.value =
+                ImageHashesDatabaseRemoteDownloadUiState(isWorking = true)
+
+            val paths = OcrDependencyPaths()
+            val cachePath =
+                Path((context.externalCacheDir ?: context.cacheDir).absolutePath) /
+                    "image-hashes-db-download.db"
+            // Staged next to the destination so the final move stays on one filesystem.
+            val stagingPath = paths.parentDir / "image-hashes.db.staging"
+
+            try {
+                if (!mkOcrDependencyParentDirs(paths)) {
+                    throw IllegalStateException("Create dependencies parent directory failed!")
+                }
+
+                resourcesApiClient.downloadImageHashesDatabase(cachePath)
+
+                // Same as manual import: the file is only promoted after it opens read-only and builds an ImageHashesDatabase.
+                OcrDependencyLoader.imageHashesSQLiteDatabase(cachePath).use { sqliteDb ->
+                    ImageHashesDatabase(sqliteDb)
+                }
+
+                // Copy to a staging file first: an interrupted direct copy would truncate the current ih.db.
+                SystemFileSystem.source(cachePath).buffered().use { src ->
+                    SystemFileSystem.sink(stagingPath).buffered().use { dst ->
+                        src.transferTo(dst)
+                    }
+                }
+
+                // atomicMove does not overwrite; remove the current file first.
+                if (SystemFileSystem.metadataOrNull(paths.imageHashesDatabaseFile) != null) {
+                    SystemFileSystem.delete(paths.imageHashesDatabaseFile)
+                }
+                SystemFileSystem.atomicMove(stagingPath, paths.imageHashesDatabaseFile)
+
+                _imageHashesDatabaseRemoteDownloadUiState.value =
+                    ImageHashesDatabaseRemoteDownloadUiState()
+                reloadImageHashesDatabaseStatusDetailUiState()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.e(e) { "Error downloading image hashes database" }
+                _imageHashesDatabaseRemoteDownloadUiState.value =
+                    ImageHashesDatabaseRemoteDownloadUiState(error = throwableToErrorText(e))
+            } finally {
+                for (path in listOf(cachePath, stagingPath)) {
+                    if (SystemFileSystem.metadataOrNull(path) != null) {
+                        SystemFileSystem.delete(path)
+                    }
+                }
+            }
+        }
     }
 
     private fun mkOcrDependencyParentDirs(ocrDependencyPaths: OcrDependencyPaths): Boolean =
@@ -123,17 +205,26 @@ class OcrDependenciesScreenViewModel(
             if (isFileTooLarge(uri, context, logName = "ImageHashesDatabase")) return@launch
 
             val cacheFile = context.copyToCache(uri, "image_hashes_db_import_temp") ?: return@launch
+            // Staged next to the destination so the final move stays on one filesystem.
+            val stagingPath = paths.parentDir / "image-hashes.db.staging"
             try {
                 // test if the input is a valid database
                 OcrDependencyLoader.imageHashesSQLiteDatabase(cacheFile).use { sqliteDb ->
                     ImageHashesDatabase(sqliteDb)
                 }
 
+                // Copy to a staging file first: an interrupted direct copy would truncate the current ih.db.
                 SystemFileSystem.source(cacheFile).buffered().use { src ->
-                    SystemFileSystem.sink(paths.imageHashesDatabaseFile).buffered().use { dst ->
+                    SystemFileSystem.sink(stagingPath).buffered().use { dst ->
                         src.transferTo(dst)
                     }
                 }
+
+                // atomicMove does not overwrite; remove the current file first.
+                if (SystemFileSystem.metadataOrNull(paths.imageHashesDatabaseFile) != null) {
+                    SystemFileSystem.delete(paths.imageHashesDatabaseFile)
+                }
+                SystemFileSystem.atomicMove(stagingPath, paths.imageHashesDatabaseFile)
             } catch (e: Exception) {
                 if (e is SQLiteException) {
                     logger.w(e) { "Input file doesn't seem like to be a SQLite database" }
@@ -141,7 +232,11 @@ class OcrDependenciesScreenViewModel(
                     logger.e(e) { "Error importing image hashes database" }
                 }
             } finally {
-                SystemFileSystem.delete(cacheFile)
+                for (path in listOf(cacheFile, stagingPath)) {
+                    if (SystemFileSystem.metadataOrNull(path) != null) {
+                        SystemFileSystem.delete(path)
+                    }
+                }
             }
 
             reloadImageHashesDatabaseStatusDetailUiState()

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.io.buffered
-import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
 import xyz.sevive.arcaeaoffline.core.Progress
 import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
@@ -42,8 +41,12 @@ import xyz.sevive.arcaeaoffline.ui.components.ocr.OcrDependencyCrnnModelStatusUi
 import xyz.sevive.arcaeaoffline.ui.components.ocr.OcrDependencyImageHashesDatabaseStatusUiState
 import java.io.IOException
 
+/**
+ * Holds the application context injected by Koin (androidContext() resolves to the Application,
+ * not an Activity), so keeping it for the ViewModel lifetime does not leak UI.
+ */
 class OcrDependenciesScreenViewModel(
-    private val context: Context,
+    context: Context,
     private val resourcesApiClient: ArcaeaResourcesApiClient,
     private val remoteResourcesInfoStateHolder: RemoteResourcesInfoStateHolder,
 ) : ViewModel() {
@@ -115,10 +118,8 @@ class OcrDependenciesScreenViewModel(
                 ImageHashesDatabaseRemoteDownloadUiState(isWorking = true)
 
             val paths = OcrDependencyPaths()
-            val cachePath =
-                Path((context.externalCacheDir ?: context.cacheDir).absolutePath) /
-                    "image-hashes-db-download.db"
-            // Staged next to the destination so the final move stays on one filesystem.
+            // Staged next to the destination so the final move stays on one filesystem; the download
+            // itself truncates the staging file, so no separate scratch copy is needed.
             val stagingPath = paths.parentDir / "image-hashes.db.staging"
 
             try {
@@ -126,18 +127,11 @@ class OcrDependenciesScreenViewModel(
                     throw IllegalStateException("Create dependencies parent directory failed!")
                 }
 
-                resourcesApiClient.downloadImageHashesDatabase(cachePath)
+                resourcesApiClient.downloadImageHashesDatabase(stagingPath)
 
                 // Same as manual import: the file is only promoted after it opens read-only and builds an ImageHashesDatabase.
-                OcrDependencyLoader.imageHashesSQLiteDatabase(cachePath).use { sqliteDb ->
+                OcrDependencyLoader.imageHashesSQLiteDatabase(stagingPath).use { sqliteDb ->
                     ImageHashesDatabase(sqliteDb)
-                }
-
-                // Copy to a staging file first: an interrupted direct copy would truncate the current ih.db.
-                SystemFileSystem.source(cachePath).buffered().use { src ->
-                    SystemFileSystem.sink(stagingPath).buffered().use { dst ->
-                        src.transferTo(dst)
-                    }
                 }
 
                 // atomicMove does not overwrite; remove the current file first.
@@ -156,10 +150,8 @@ class OcrDependenciesScreenViewModel(
                 _imageHashesDatabaseRemoteDownloadUiState.value =
                     ImageHashesDatabaseRemoteDownloadUiState(error = throwableToErrorText(e))
             } finally {
-                for (path in listOf(cachePath, stagingPath)) {
-                    if (SystemFileSystem.metadataOrNull(path) != null) {
-                        SystemFileSystem.delete(path)
-                    }
+                if (SystemFileSystem.metadataOrNull(stagingPath) != null) {
+                    SystemFileSystem.delete(stagingPath)
                 }
             }
         }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
@@ -120,10 +120,12 @@ class OcrDependenciesScreenViewModel(
         if (_imageHashesDatabaseRemoteDownloadUiState.value.isWorking) return
         if (_imageHashesDatabaseImportRunning.value) return
 
-        viewModelScope.launch(Dispatchers.IO) {
-            _imageHashesDatabaseRemoteDownloadUiState.value =
-                ImageHashesDatabaseRemoteDownloadUiState(isWorking = true)
+        // Set before dispatching: the IO coroutine runs later, and a double tap in that window
+        // would otherwise pass the guard twice and race on the shared staging file.
+        _imageHashesDatabaseRemoteDownloadUiState.value =
+            ImageHashesDatabaseRemoteDownloadUiState(isWorking = true)
 
+        viewModelScope.launch(Dispatchers.IO) {
             val paths = OcrDependencyPaths()
             // Staged next to the destination so the final move stays on one filesystem; the download
             // itself truncates the staging file, so no separate scratch copy is needed.
@@ -201,8 +203,11 @@ class OcrDependenciesScreenViewModel(
         val paths = OcrDependencyPaths()
         if (!mkOcrDependencyParentDirs(paths)) return
 
+        // Set before dispatching, same as [requestImageHashesDatabaseDownload]: both flows write
+        // the same files, so the flag must be visible to the next click before any suspension.
+        _imageHashesDatabaseImportRunning.value = true
+
         viewModelScope.launch(Dispatchers.IO) {
-            _imageHashesDatabaseImportRunning.value = true
             try {
                 context.uriSizeIfTooLarge(uri)?.let { actualSize ->
                     logger.w {

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/ocr/dependencies/OcrDependenciesScreenViewModel.kt
@@ -34,7 +34,7 @@ import xyz.sevive.arcaeaoffline.helpers.ImageHashesDatabaseStatusDetail
 import xyz.sevive.arcaeaoffline.helpers.OcrDependencyLoader
 import xyz.sevive.arcaeaoffline.helpers.OcrDependencyStatusBuilder
 import xyz.sevive.arcaeaoffline.helpers.context.copyToCache
-import xyz.sevive.arcaeaoffline.helpers.context.getFileSize
+import xyz.sevive.arcaeaoffline.helpers.context.uriSizeIfTooLarge
 import xyz.sevive.arcaeaoffline.helpers.fromWorkInfo
 import xyz.sevive.arcaeaoffline.jobs.ImageHashesDatabaseBuilderJob
 import xyz.sevive.arcaeaoffline.ui.components.ocr.OcrDependencyCrnnModelStatusUiState
@@ -169,26 +169,6 @@ class OcrDependenciesScreenViewModel(
             false
         }
 
-    private fun isFileTooLarge(
-        uri: Uri,
-        context: Context,
-        limit: Long = 20 * 1024 * 1024,
-        logName: String? = null,
-    ): Boolean {
-        val fileSize = context.getFileSize(uri) ?: return false
-        if (fileSize <= limit) return false
-
-        logger.w {
-            buildString {
-                logName?.let { append("[$logName] ") }
-                append("Input file too large, ")
-                append("limit is ${Formatter.formatFileSize(context, limit)} ")
-                append("while input is ${Formatter.formatFileSize(context, fileSize)}!")
-            }
-        }
-        return true
-    }
-
     fun importImageHashesDatabase(
         uri: Uri,
         context: Context,
@@ -202,7 +182,16 @@ class OcrDependenciesScreenViewModel(
         viewModelScope.launch(Dispatchers.IO) {
             _imageHashesDatabaseImportRunning.value = true
             try {
-                if (isFileTooLarge(uri, context, logName = "ImageHashesDatabase")) return@launch
+                context.uriSizeIfTooLarge(uri)?.let { actualSize ->
+                    logger.w {
+                        "[ImageHashesDatabase] Input file too large, limit is ${Formatter.formatFileSize(
+                            context,
+                            ArcaeaResourcesApiClient.DEFAULT_MAX_RESOURCE_BYTES,
+                        )} " +
+                            "while input is ${Formatter.formatFileSize(context, actualSize)}!"
+                    }
+                    return@launch
+                }
 
                 val cacheFile = context.copyToCache(uri, "image_hashes_db_import_temp") ?: return@launch
                 // Staged next to the destination so the final move stays on one filesystem.

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/SettingsScreen.kt
@@ -36,6 +36,7 @@ fun SettingsScreen(vm: SettingsViewModel = koinViewModel()) {
                     SettingsGeneralScreen(
                         uiState = generalUiState,
                         onSetAutoSendCrashReports = { vm.setAutoSendCrashReports(it) },
+                        onSetResourcesApiBaseUrl = { vm.setResourcesApiBaseUrl(it) },
                     )
                 }
 

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/SettingsViewModel.kt
@@ -14,6 +14,7 @@ class SettingsViewModel(
 ) : ViewModel() {
     data class AppPreferencesUiState(
         val autoSendCrashReports: Boolean = false,
+        val resourcesApiBaseUrl: String = "",
     )
 
     val appPreferencesUiState =
@@ -21,12 +22,19 @@ class SettingsViewModel(
             .map {
                 AppPreferencesUiState(
                     autoSendCrashReports = it.autoSendCrashReports,
+                    resourcesApiBaseUrl = it.resourcesApiBaseUrl,
                 )
             }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(2500L), AppPreferencesUiState())
 
     fun setAutoSendCrashReports(value: Boolean) {
         viewModelScope.launch(Dispatchers.IO) {
             appPreferencesRepository.setAutoSendCrashReports(value)
+        }
+    }
+
+    fun setResourcesApiBaseUrl(value: String) {
+        viewModelScope.launch(Dispatchers.IO) {
+            appPreferencesRepository.setResourcesApiBaseUrl(value)
         }
     }
 }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/SettingsViewModel.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/SettingsViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
 import xyz.sevive.arcaeaoffline.datastore.AppPreferencesRepository
 
 class SettingsViewModel(
@@ -14,7 +15,7 @@ class SettingsViewModel(
 ) : ViewModel() {
     data class AppPreferencesUiState(
         val autoSendCrashReports: Boolean = false,
-        val resourcesApiBaseUrl: String = "",
+        val resourcesApiBaseUrl: String = ArcaeaResourcesApiClient.DEFAULT_BASE_URL,
     )
 
     val appPreferencesUiState =

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/general/SettingsGeneralScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/general/SettingsGeneralScreen.kt
@@ -1,23 +1,97 @@
 package xyz.sevive.arcaeaoffline.ui.screens.settings.general
 
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.Undo
 import androidx.compose.material.icons.filled.BugReport
+import androidx.compose.material.icons.filled.CloudDownload
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.KeyboardType
 import xyz.sevive.arcaeaoffline.R
+import xyz.sevive.arcaeaoffline.core.api.ArcaeaResourcesApiClient
 import xyz.sevive.arcaeaoffline.ui.SubScreenContainer
+import xyz.sevive.arcaeaoffline.ui.components.dialogs.DialogConfirmButton
+import xyz.sevive.arcaeaoffline.ui.components.dialogs.DialogDismissTextButton
 import xyz.sevive.arcaeaoffline.ui.components.preferences.SwitchPreferencesWidget
+import xyz.sevive.arcaeaoffline.ui.components.preferences.TextPreferencesWidget
 import xyz.sevive.arcaeaoffline.ui.navigation.SettingsSubScreen
 import xyz.sevive.arcaeaoffline.ui.screens.settings.SettingsViewModel
+
+@Composable
+private fun ResourcesApiBaseUrlEditDialog(
+    initialValue: String,
+    onConfirm: (String) -> Unit,
+    onReset: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    var value by rememberSaveable { mutableStateOf(initialValue) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.settings_general_pref_resources_api_base_url_dialog_title)) },
+        text = {
+            TextField(
+                value = value,
+                onValueChange = { value = it },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        dismissButton = {
+            DialogDismissTextButton(
+                onClick = {
+                    onReset()
+                    onDismiss()
+                },
+                customIcon = { Icon(Icons.AutoMirrored.Filled.Undo, contentDescription = null) },
+                customLabel = { Text(stringResource(R.string.general_reset)) },
+            )
+        },
+        confirmButton = {
+            DialogConfirmButton(
+                onClick = {
+                    onConfirm(value.trim())
+                    onDismiss()
+                },
+                enabled = value.isNotBlank(),
+                customIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
+                customLabel = { Text(stringResource(R.string.general_save)) },
+            )
+        },
+    )
+}
 
 @Composable
 internal fun SettingsGeneralScreen(
     uiState: SettingsViewModel.AppPreferencesUiState,
     onSetAutoSendCrashReports: (Boolean) -> Unit,
+    onSetResourcesApiBaseUrl: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var showBaseUrlEditDialog by rememberSaveable { mutableStateOf(false) }
+    if (showBaseUrlEditDialog) {
+        ResourcesApiBaseUrlEditDialog(
+            initialValue = uiState.resourcesApiBaseUrl.ifBlank { ArcaeaResourcesApiClient.DEFAULT_BASE_URL },
+            onConfirm = onSetResourcesApiBaseUrl,
+            onReset = { onSetResourcesApiBaseUrl(ArcaeaResourcesApiClient.DEFAULT_BASE_URL) },
+            onDismiss = { showBaseUrlEditDialog = false },
+        )
+    }
+
     SubScreenContainer(
         title = stringResource(SettingsSubScreen.General.title),
     ) {
@@ -28,6 +102,15 @@ internal fun SettingsGeneralScreen(
                     onValueChange = { onSetAutoSendCrashReports(it) },
                     icon = Icons.Default.BugReport,
                     title = stringResource(R.string.settings_app_pref_enable_sentry),
+                )
+            }
+
+            item {
+                TextPreferencesWidget(
+                    onClick = { showBaseUrlEditDialog = true },
+                    leadingIcon = Icons.Default.CloudDownload,
+                    title = stringResource(R.string.settings_general_pref_resources_api_base_url),
+                    content = uiState.resourcesApiBaseUrl,
                 )
             }
         }

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/general/SettingsGeneralScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/general/SettingsGeneralScreen.kt
@@ -55,6 +55,10 @@ private fun ResourcesApiBaseUrlEditDialog(
                 supportingText = {
                     if (value.isNotBlank() && !isValid) {
                         Text(stringResource(R.string.settings_general_pref_resources_api_base_url_invalid))
+                    } else if (trimmed.startsWith("http://")) {
+                        // Android 9+ silently blocks cleartext: an http URL is "valid" here, but
+                        // every probe and download would fail with a generic network error.
+                        Text(stringResource(R.string.settings_general_pref_resources_api_base_url_http_hint))
                     }
                 },
                 modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/general/SettingsGeneralScreen.kt
+++ b/app/src/main/java/xyz/sevive/arcaeaoffline/ui/screens/settings/general/SettingsGeneralScreen.kt
@@ -39,6 +39,9 @@ private fun ResourcesApiBaseUrlEditDialog(
 ) {
     var value by rememberSaveable { mutableStateOf(initialValue) }
 
+    val trimmed = value.trim()
+    val isValid = trimmed.startsWith("http://") || trimmed.startsWith("https://")
+
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.settings_general_pref_resources_api_base_url_dialog_title)) },
@@ -48,6 +51,12 @@ private fun ResourcesApiBaseUrlEditDialog(
                 onValueChange = { value = it },
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                isError = value.isNotBlank() && !isValid,
+                supportingText = {
+                    if (value.isNotBlank() && !isValid) {
+                        Text(stringResource(R.string.settings_general_pref_resources_api_base_url_invalid))
+                    }
+                },
                 modifier = Modifier.fillMaxWidth(),
             )
         },
@@ -64,10 +73,10 @@ private fun ResourcesApiBaseUrlEditDialog(
         confirmButton = {
             DialogConfirmButton(
                 onClick = {
-                    onConfirm(value.trim())
+                    onConfirm(trimmed)
                     onDismiss()
                 },
-                enabled = value.isNotBlank(),
+                enabled = isValid,
                 customIcon = { Icon(Icons.Default.Edit, contentDescription = null) },
                 customLabel = { Text(stringResource(R.string.general_save)) },
             )
@@ -85,7 +94,7 @@ internal fun SettingsGeneralScreen(
     var showBaseUrlEditDialog by rememberSaveable { mutableStateOf(false) }
     if (showBaseUrlEditDialog) {
         ResourcesApiBaseUrlEditDialog(
-            initialValue = uiState.resourcesApiBaseUrl.ifBlank { ArcaeaResourcesApiClient.DEFAULT_BASE_URL },
+            initialValue = uiState.resourcesApiBaseUrl,
             onConfirm = onSetResourcesApiBaseUrl,
             onReset = { onSetResourcesApiBaseUrl(ArcaeaResourcesApiClient.DEFAULT_BASE_URL) },
             onDismiss = { showBaseUrlEditDialog = false },

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -20,6 +20,8 @@
     <string name="general_no_results">无结果</string>
     <string name="general_updated_at">更新于 %s</string>
     <string name="general_unknown_error">未知错误</string>
+    <string name="general_unknown">未知</string>
+    <string name="general_downloading">正在下载……</string>
 
     <string name="general_sort_ascending">升序</string>
     <string name="general_sort_ascending_short">升序</string>
@@ -139,7 +141,12 @@
     <string name="database_manage_import_from_arcaea_installed">从 Arcaea 导入</string>
     <string name="database_manage_import_chart_info_database">谱面信息数据库</string>
 
+    <string name="database_manage_download_title">从网络下载…</string>
     <string name="database_manage_refresh_remote_info">刷新远端状态</string>
+    <string name="database_manage_download_packlist">packlist</string>
+    <string name="database_manage_download_songlist">songlist</string>
+    <string name="database_manage_download_chart_info_database">谱面信息数据库</string>
+    <string name="database_manage_download_started">正在下载……</string>
     <string name="database_manage_export_title">导出</string>
     <string name="database_manage_export_play_results">游玩记录</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -147,6 +147,8 @@
     <string name="database_manage_download_songlist">songlist</string>
     <string name="database_manage_download_chart_info_database">谱面信息数据库</string>
     <string name="database_manage_download_started">正在下载……</string>
+    <string name="ocr_dependencies_download_from_network">从网络下载</string>
+
     <string name="database_manage_export_title">导出</string>
     <string name="database_manage_export_play_results">游玩记录</string>
 

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -302,6 +302,7 @@
     <string name="settings_general_pref_resources_api_base_url">资源 API base URL</string>
     <string name="settings_general_pref_resources_api_base_url_dialog_title">编辑资源 API base URL</string>
     <string name="settings_general_pref_resources_api_base_url_invalid">必须以 http:// 或 https:// 开头</string>
+    <string name="settings_general_pref_resources_api_base_url_http_hint">Android 9 及以上默认禁止明文（http://）流量，非 HTTPS 服务器可能无法访问</string>
     <string name="settings_about_title">关于</string>
     <string name="settings_about_application_id">应用 ID</string>
     <string name="settings_about_version">版本</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -139,6 +139,7 @@
     <string name="database_manage_import_from_arcaea_installed">从 Arcaea 导入</string>
     <string name="database_manage_import_chart_info_database">谱面信息数据库</string>
 
+    <string name="database_manage_refresh_remote_info">刷新远端状态</string>
     <string name="database_manage_export_title">导出</string>
     <string name="database_manage_export_play_results">游玩记录</string>
 
@@ -289,6 +290,8 @@
     <!-- SettingsScreen -->
     <string name="settings_app_pref_enable_sentry">发送崩溃报告</string>
     <string name="settings_general_title">通用</string>
+    <string name="settings_general_pref_resources_api_base_url">资源 API base URL</string>
+    <string name="settings_general_pref_resources_api_base_url_dialog_title">编辑资源 API base URL</string>
     <string name="settings_about_title">关于</string>
     <string name="settings_about_application_id">应用 ID</string>
     <string name="settings_about_version">版本</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -301,6 +301,7 @@
     <string name="settings_general_title">通用</string>
     <string name="settings_general_pref_resources_api_base_url">资源 API base URL</string>
     <string name="settings_general_pref_resources_api_base_url_dialog_title">编辑资源 API base URL</string>
+    <string name="settings_general_pref_resources_api_base_url_invalid">必须以 http:// 或 https:// 开头</string>
     <string name="settings_about_title">关于</string>
     <string name="settings_about_application_id">应用 ID</string>
     <string name="settings_about_version">版本</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@ CC BY-SA 3.0
     <string name="database_manage_import_from_arcaea_installed">From installed Arcaea</string>
     <string name="database_manage_import_chart_info_database">Chart Info Database</string>
 
+    <string name="database_manage_refresh_remote_info">Refresh remote status</string>
     <string name="database_manage_export_title">Export…</string>
     <string name="database_manage_export_play_results">Play Results</string>
 
@@ -322,6 +323,8 @@ CC BY-SA 3.0
     <!-- SettingsScreen -->
     <string name="settings_app_pref_enable_sentry">Send crash reports</string>
     <string name="settings_general_title">General</string>
+    <string name="settings_general_pref_resources_api_base_url">Resources API base URL</string>
+    <string name="settings_general_pref_resources_api_base_url_dialog_title">Edit resources API base URL</string>
     <string name="settings_about_title">About</string>
     <string name="settings_about_application_id">Application ID</string>
     <string name="settings_about_version">Version</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,6 +335,7 @@ CC BY-SA 3.0
     <string name="settings_general_pref_resources_api_base_url">Resources API base URL</string>
     <string name="settings_general_pref_resources_api_base_url_dialog_title">Edit resources API base URL</string>
     <string name="settings_general_pref_resources_api_base_url_invalid">Must start with http:// or https://</string>
+    <string name="settings_general_pref_resources_api_base_url_http_hint">Android 9 and above block cleartext (http://) traffic; a non-HTTPS server may be unreachable.</string>
     <string name="settings_about_title">About</string>
     <string name="settings_about_application_id">Application ID</string>
     <string name="settings_about_version">Version</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,8 @@ CC BY-SA 3.0
     <string name="general_no_results">No results</string>
     <string name="general_updated_at">Updated at %s</string>
     <string name="general_unknown_error">Unknown error.</string>
+    <string name="general_unknown">Unknown</string>
+    <string name="general_downloading">Downloading…</string>
 
     <string name="general_sort_ascending">Ascending</string>
     <string name="general_sort_ascending_short">ASC</string>
@@ -160,7 +162,12 @@ CC BY-SA 3.0
     <string name="database_manage_import_from_arcaea_installed">From installed Arcaea</string>
     <string name="database_manage_import_chart_info_database">Chart Info Database</string>
 
+    <string name="database_manage_download_title">Download from network…</string>
     <string name="database_manage_refresh_remote_info">Refresh remote status</string>
+    <string name="database_manage_download_packlist">packlist</string>
+    <string name="database_manage_download_songlist">songlist</string>
+    <string name="database_manage_download_chart_info_database">Chart Info Database</string>
+    <string name="database_manage_download_started">Downloading…</string>
     <string name="database_manage_export_title">Export…</string>
     <string name="database_manage_export_play_results">Play Results</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -334,6 +334,7 @@ CC BY-SA 3.0
     <string name="settings_general_title">General</string>
     <string name="settings_general_pref_resources_api_base_url">Resources API base URL</string>
     <string name="settings_general_pref_resources_api_base_url_dialog_title">Edit resources API base URL</string>
+    <string name="settings_general_pref_resources_api_base_url_invalid">Must start with http:// or https://</string>
     <string name="settings_about_title">About</string>
     <string name="settings_about_application_id">Application ID</string>
     <string name="settings_about_version">Version</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -168,6 +168,8 @@ CC BY-SA 3.0
     <string name="database_manage_download_songlist">songlist</string>
     <string name="database_manage_download_chart_info_database">Chart Info Database</string>
     <string name="database_manage_download_started">Downloading…</string>
+    <string name="ocr_dependencies_download_from_network">Download from network</string>
+
     <string name="database_manage_export_title">Export…</string>
     <string name="database_manage_export_play_results">Play Results</string>
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ androidGradlePlugin = "9.2.1"
 desugarJdkLibs = "2.1.5"
 
 kotlin = "2.3.21"
+kotlinx-coroutines = "1.10.2"
 kotlinx-serialization = "1.11.0"
 ktoml = "0.7.1"
 kotlinx-datetime = "0.8.0"
@@ -27,6 +28,7 @@ aboutlibraries = "14.2.1"
 kermit = "2.1.0"
 filekit = "0.14.2"
 kotlinx-io = "0.9.0"
+ktor = "3.5.2"
 bignum = "0.3.10"
 kim = "0.31.0"
 
@@ -84,6 +86,11 @@ kermit = { module = "co.touchlab:kermit", version.ref = "kermit" }
 filekit-core = { module = "io.github.vinceglb:filekit-core", version.ref = "filekit" }
 filekit-dialogs-compose = { module = "io.github.vinceglb:filekit-dialogs-compose", version.ref = "filekit" }
 kotlinx-io = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
 bignum = { module = "com.ionspin.kotlin:bignum", version.ref = "bignum" }
 kim = { module = "de.stefan-oltmann:kim", version.ref = "kim" }
 

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -67,15 +67,26 @@ kotlin {
             implementation(libs.kotlinx.serialization)
 
             implementation(libs.bignum)
+            implementation(libs.kermit)
+
+            implementation(libs.ktor.client.core)
+        }
+
+        androidMain.dependencies {
+            implementation(libs.ktor.client.okhttp)
         }
 
         jvmMain.dependencies {
             implementation(libs.jSystemThemeDetector)
+            implementation(libs.ktor.client.cio)
         }
 
         commonTest.dependencies {
             implementation(kotlin("test"))
             implementation(libs.compose.ui.test)
+            implementation(libs.ktor.client.core)
+            implementation(libs.ktor.client.mock)
+            implementation(libs.kotlinx.coroutines.test)
         }
 
         jvmTest.dependencies {

--- a/shared/src/androidMain/kotlin/xyz/sevive/arcaeaoffline/core/api/PlatformHttpClient.android.kt
+++ b/shared/src/androidMain/kotlin/xyz/sevive/arcaeaoffline/core/api/PlatformHttpClient.android.kt
@@ -1,0 +1,9 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.okhttp.OkHttp
+
+actual fun platformHttpClient(): HttpClient =
+    HttpClient(OkHttp) {
+        resourcesApiTimeouts()
+    }

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
@@ -1,0 +1,231 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.head
+import io.ktor.client.request.prepareGet
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsChannel
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.isSuccess
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.readRemaining
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlin.time.Instant
+
+class ArcaeaResourcesApiException(
+    val status: HttpStatusCode,
+    url: String,
+) : RuntimeException("Request to $url failed with status $status")
+
+@Serializable
+internal data class RemoteIndexDto(
+    @SerialName("latest") val latest: String,
+    @SerialName("versions") val versions: List<RemoteIndexVersionDto> = emptyList(),
+)
+
+@Serializable
+internal data class RemoteIndexVersionDto(
+    @SerialName("version") val version: String,
+    @SerialName("built_at") val builtAt: String? = null,
+)
+
+private val json = Json { ignoreUnknownKeys = true }
+
+/** Raw error text for display: exception class name + message, if any. */
+fun throwableToErrorText(e: Throwable): String =
+    buildString {
+        append(e::class.simpleName ?: "Exception")
+        e.message?.let { append(": ").append(it) }
+    }
+
+internal fun parseRemoteIndex(text: String): RemoteIndexDto = json.decodeFromString<RemoteIndexDto>(text)
+
+internal fun parseBuiltAt(text: String): Long? = runCatching { Instant.parse(text).toEpochMilliseconds() }.getOrNull()
+
+/** Probe result of a single remote file. */
+data class ArcaeaResourcesRemoteFileInfo(
+    val isAvailable: Boolean,
+    /** Version from index.json's latest; null if the index could not be fetched. */
+    val version: String?,
+    /** built_at of that version from index.json, epoch milliseconds; null if missing or unparsable. */
+    val builtAt: Long?,
+    /** Reason when isAvailable = false: an HTTP status code, or an exception class name with message. */
+    val errorText: String?,
+)
+
+/** Remote metadata of the publish directory. */
+data class ArcaeaResourcesRemoteInfo(
+    val packlist: ArcaeaResourcesRemoteFileInfo,
+    val songlist: ArcaeaResourcesRemoteFileInfo,
+    val chartInfoDatabase: ArcaeaResourcesRemoteFileInfo,
+    val imageHashesDatabase: ArcaeaResourcesRemoteFileInfo,
+) {
+    operator fun get(resource: DownloadableResource): ArcaeaResourcesRemoteFileInfo =
+        when (resource) {
+            DownloadableResource.PACKLIST -> packlist
+            DownloadableResource.SONGLIST -> songlist
+            DownloadableResource.CHART_INFO_DATABASE -> chartInfoDatabase
+            DownloadableResource.IMAGE_HASHES_DATABASE -> imageHashesDatabase
+        }
+}
+
+class ArcaeaResourcesApiClient(
+    private val baseUrlFlow: Flow<String>,
+    private val httpClient: HttpClient = platformHttpClient(),
+) {
+    companion object {
+        const val DEFAULT_BASE_URL = "https://arcaeaoffline.sevive.xyz/publish"
+        private const val INDEX_FILE_NAME = "index.json"
+        private const val DOWNLOAD_CHUNK_SIZE = 64 * 1024
+    }
+
+    suspend fun packlist(): String = publishText(versionedPath(DownloadableResource.PACKLIST))
+
+    suspend fun songlist(): String = publishText(versionedPath(DownloadableResource.SONGLIST))
+
+    /** Fetches the index first, then probes every published file in parallel; one file's failure does not affect the others. */
+    suspend fun fetchRemoteInfo(): ArcaeaResourcesRemoteInfo =
+        coroutineScope {
+            val (index, indexErrorText) =
+                try {
+                    fetchIndex() to null
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    null to throwableToErrorText(e)
+                }
+
+            val latest = index?.latest
+            val builtAt = index?.builtAt
+
+            val packlist = async { fetchFileInfo(DownloadableResource.PACKLIST, latest, builtAt, indexErrorText) }
+            val songlist = async { fetchFileInfo(DownloadableResource.SONGLIST, latest, builtAt, indexErrorText) }
+            val chartInfoDatabase = async { fetchFileInfo(DownloadableResource.CHART_INFO_DATABASE, latest, builtAt, indexErrorText) }
+            val imageHashesDatabase = async { fetchFileInfo(DownloadableResource.IMAGE_HASHES_DATABASE, latest, builtAt, indexErrorText) }
+
+            ArcaeaResourcesRemoteInfo(
+                packlist = packlist.await(),
+                songlist = songlist.await(),
+                chartInfoDatabase = chartInfoDatabase.await(),
+                imageHashesDatabase = imageHashesDatabase.await(),
+            )
+        }
+
+    /** Streams ci.db to [dest] without content validation; validation is up to the caller's import flow. */
+    suspend fun downloadChartInfoDatabase(dest: Path) = downloadFile(DownloadableResource.CHART_INFO_DATABASE, dest)
+
+    /** Streams ih.db to [dest] without content validation; validation is up to the caller's import flow. */
+    suspend fun downloadImageHashesDatabase(dest: Path) = downloadFile(DownloadableResource.IMAGE_HASHES_DATABASE, dest)
+
+    private data class ResolvedIndex(
+        val latest: String,
+        val builtAt: Long?,
+    )
+
+    /** Versioned path segment: fetch the index for latest, then compose "{latest}/{resource.fileName}". */
+    private suspend fun versionedPath(resource: DownloadableResource): String {
+        val index = fetchIndex()
+        return "${index.latest}/${resource.fileName}"
+    }
+
+    private suspend fun fetchIndex(): ResolvedIndex {
+        val dto = parseRemoteIndex(publishText(INDEX_FILE_NAME))
+        val builtAt =
+            dto.versions
+                .firstOrNull { it.version == dto.latest }
+                ?.builtAt
+                ?.let(::parseBuiltAt)
+        return ResolvedIndex(dto.latest, builtAt)
+    }
+
+    private suspend fun publishText(path: String): String {
+        val url = publishUrl(path)
+        val response = httpClient.get(url)
+        response.checkStatus(url)
+        return response.bodyAsText()
+    }
+
+    /** HEAD-probes a file; network failures count as unavailable with the reason recorded, never thrown. */
+    private suspend fun fetchFileInfo(
+        resource: DownloadableResource,
+        version: String?,
+        builtAt: Long?,
+        indexErrorText: String?,
+    ): ArcaeaResourcesRemoteFileInfo {
+        if (version == null) {
+            // Index fetch failed: the versioned path is unknown, so report the index error for every file.
+            return ArcaeaResourcesRemoteFileInfo(false, null, null, indexErrorText)
+        }
+
+        val isAvailableAndErrorText =
+            try {
+                val url = publishUrl("$version/${resource.fileName}")
+                val response = httpClient.head(url)
+
+                if (response.status.isSuccess()) {
+                    true to null
+                } else {
+                    false to response.status.value.toString()
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                false to throwableToErrorText(e)
+            }
+
+        return ArcaeaResourcesRemoteFileInfo(
+            isAvailable = isAvailableAndErrorText.first,
+            version = version,
+            builtAt = builtAt,
+            errorText = isAvailableAndErrorText.second,
+        )
+    }
+
+    private suspend fun publishUrl(fileName: String): String {
+        val baseUrl = baseUrlFlow.first().trim().trimEnd('/')
+        return "$baseUrl/$fileName"
+    }
+
+    private fun HttpResponse.checkStatus(url: String) {
+        if (!status.isSuccess()) throw ArcaeaResourcesApiException(status, url)
+    }
+
+    private suspend fun downloadFile(
+        resource: DownloadableResource,
+        dest: Path,
+    ) {
+        val url = publishUrl(versionedPath(resource))
+        httpClient.prepareGet(url).execute { response ->
+            response.checkStatus(url)
+            copyBodyToFile(response.bodyAsChannel(), dest)
+        }
+    }
+
+    private suspend fun copyBodyToFile(
+        channel: ByteReadChannel,
+        dest: Path,
+    ) {
+        SystemFileSystem.sink(dest).buffered().use { sink ->
+            val buffer = ByteArray(DOWNLOAD_CHUNK_SIZE)
+            while (!channel.isClosedForRead) {
+                val chunk = channel.readRemaining(DOWNLOAD_CHUNK_SIZE.toLong())
+                while (!chunk.exhausted()) {
+                    val read = chunk.readAtMostTo(buffer)
+                    sink.write(buffer, 0, read)
+                }
+            }
+        }
+    }
+}

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
@@ -6,8 +6,8 @@ import io.ktor.client.request.head
 import io.ktor.client.request.prepareGet
 import io.ktor.client.statement.HttpResponse
 import io.ktor.client.statement.bodyAsChannel
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentLength
 import io.ktor.http.isSuccess
 import io.ktor.utils.io.ByteReadChannel
 import io.ktor.utils.io.readRemaining
@@ -16,9 +16,13 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.io.Buffer
+import kotlinx.io.IOException
+import kotlinx.io.Sink
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.readByteArray
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
@@ -85,11 +89,13 @@ data class ArcaeaResourcesRemoteInfo(
 open class ArcaeaResourcesApiClient(
     private val baseUrlFlow: Flow<String>,
     private val httpClient: HttpClient = platformHttpClient(),
+    private val maxResourceBytes: Long = DEFAULT_MAX_RESOURCE_BYTES,
 ) {
     companion object {
         const val DEFAULT_BASE_URL = "https://arcaeaoffline.sevive.xyz/publish"
         private const val INDEX_FILE_NAME = "index.json"
         private const val DOWNLOAD_CHUNK_SIZE = 64 * 1024
+        private const val DEFAULT_MAX_RESOURCE_BYTES = 20L * 1024 * 1024
     }
 
     suspend fun packlist(): String = publishText(versionedPath(DownloadableResource.PACKLIST))
@@ -155,7 +161,11 @@ open class ArcaeaResourcesApiClient(
         val url = publishUrl(path)
         val response = httpClient.get(url)
         response.checkStatus(url)
-        return response.bodyAsText()
+        response.checkDeclaredSize(url)
+
+        val buffer = Buffer()
+        copyBodyWithinLimit(response.bodyAsChannel(), buffer, url)
+        return buffer.readByteArray().decodeToString()
     }
 
     /** HEAD-probes a file; network failures count as unavailable with the reason recorded, never thrown. */
@@ -210,23 +220,36 @@ open class ArcaeaResourcesApiClient(
         val url = publishUrl(versionedPath(resource))
         httpClient.prepareGet(url).execute { response ->
             response.checkStatus(url)
-            copyBodyToFile(response.bodyAsChannel(), dest)
-        }
-    }
-
-    private suspend fun copyBodyToFile(
-        channel: ByteReadChannel,
-        dest: Path,
-    ) {
-        SystemFileSystem.sink(dest).buffered().use { sink ->
-            val buffer = ByteArray(DOWNLOAD_CHUNK_SIZE)
-            while (!channel.isClosedForRead) {
-                val chunk = channel.readRemaining(DOWNLOAD_CHUNK_SIZE.toLong())
-                while (!chunk.exhausted()) {
-                    val read = chunk.readAtMostTo(buffer)
-                    sink.write(buffer, 0, read)
-                }
+            response.checkDeclaredSize(url)
+            SystemFileSystem.sink(dest).buffered().use { sink ->
+                copyBodyWithinLimit(response.bodyAsChannel(), sink, url)
             }
         }
     }
+
+    /** Fails fast on a declared oversized body; chunked responses have no Content-Length and rely on the streamed bound. */
+    private fun HttpResponse.checkDeclaredSize(url: String) {
+        val declared = contentLength() ?: return
+        if (declared > maxResourceBytes) throw oversizedException(url)
+    }
+
+    private suspend fun copyBodyWithinLimit(
+        channel: ByteReadChannel,
+        sink: Sink,
+        url: String,
+    ) {
+        val buffer = ByteArray(DOWNLOAD_CHUNK_SIZE)
+        var total = 0L
+        while (!channel.isClosedForRead) {
+            val chunk = channel.readRemaining(DOWNLOAD_CHUNK_SIZE.toLong())
+            while (!chunk.exhausted()) {
+                val read = chunk.readAtMostTo(buffer)
+                total += read
+                if (total > maxResourceBytes) throw oversizedException(url)
+                sink.write(buffer, 0, read)
+            }
+        }
+    }
+
+    private fun oversizedException(url: String) = IOException("Resource at $url exceeds the $maxResourceBytes byte limit")
 }

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
@@ -187,10 +187,21 @@ open class ArcaeaResourcesApiClient(
                 val url = publishUrl("$version/${resource.fileName}")
                 val response = httpClient.head(url)
 
-                if (response.status.isSuccess()) {
-                    true to null
-                } else {
-                    false to response.status.value.toString()
+                when {
+                    !response.status.isSuccess() -> {
+                        false to response.status.value.toString()
+                    }
+
+                    else -> {
+                        val declared = response.contentLength()
+                        if (declared != null && declared > maxResourceBytes) {
+                            // Reject at probe time: the download would hit the streamed size
+                            // bound anyway, so surface the reason where the item is shown.
+                            false to "Content-Length $declared exceeds the $maxResourceBytes byte limit"
+                        } else {
+                            true to null
+                        }
+                    }
                 }
             } catch (e: CancellationException) {
                 throw e

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
@@ -81,7 +81,8 @@ data class ArcaeaResourcesRemoteInfo(
         }
 }
 
-class ArcaeaResourcesApiClient(
+// open for testing: holder tests override fetchRemoteInfo to exercise the holder's failure path.
+open class ArcaeaResourcesApiClient(
     private val baseUrlFlow: Flow<String>,
     private val httpClient: HttpClient = platformHttpClient(),
 ) {
@@ -96,7 +97,7 @@ class ArcaeaResourcesApiClient(
     suspend fun songlist(): String = publishText(versionedPath(DownloadableResource.SONGLIST))
 
     /** Fetches the index first, then probes every published file in parallel; one file's failure does not affect the others. */
-    suspend fun fetchRemoteInfo(): ArcaeaResourcesRemoteInfo =
+    open suspend fun fetchRemoteInfo(): ArcaeaResourcesRemoteInfo =
         coroutineScope {
             val (index, indexErrorText) =
                 try {

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClient.kt
@@ -95,7 +95,9 @@ open class ArcaeaResourcesApiClient(
         const val DEFAULT_BASE_URL = "https://arcaeaoffline.sevive.xyz/publish"
         private const val INDEX_FILE_NAME = "index.json"
         private const val DOWNLOAD_CHUNK_SIZE = 64 * 1024
-        private const val DEFAULT_MAX_RESOURCE_BYTES = 20L * 1024 * 1024
+
+        /** Also the cap for manual imports; app-side helpers reference it so both paths move together. */
+        const val DEFAULT_MAX_RESOURCE_BYTES = 20L * 1024 * 1024
     }
 
     suspend fun packlist(): String = publishText(versionedPath(DownloadableResource.PACKLIST))

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/DownloadableResource.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/DownloadableResource.kt
@@ -1,0 +1,11 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+/** A file published under the versioned publish directory; [fileName] is the path segment below "{version}/". */
+enum class DownloadableResource(
+    val fileName: String,
+) {
+    PACKLIST("packlist"),
+    SONGLIST("songlist"),
+    CHART_INFO_DATABASE("ci.db"),
+    IMAGE_HASHES_DATABASE("ih.db"),
+}

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/PlatformHttpClient.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/PlatformHttpClient.kt
@@ -1,0 +1,23 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.plugins.HttpTimeout
+
+/** Client construction is delegated per platform:
+ * - Android uses the OkHttp engine (the official Android engine is deprecated)
+ * - JVM uses CIO.
+ */
+expect fun platformHttpClient(): HttpClient
+
+/**
+ * Bounds shared by every request to the resources API. [HttpTimeout.requestTimeoutMillis] covers
+ * the whole exchange including body transfer, so it must fit the largest published file (~1MB)
+ * at weak-network throughput; connection failures surface within the much shorter connect timeout instead.
+ */
+internal fun HttpClientConfig<*>.resourcesApiTimeouts() {
+    install(HttpTimeout) {
+        connectTimeoutMillis = 15_000
+        requestTimeoutMillis = 120_000
+    }
+}

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolder.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolder.kt
@@ -11,6 +11,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 
 data class RemoteResourcesInfoUiState(
     val isFetching: Boolean = false,
@@ -30,12 +32,14 @@ class RemoteResourcesInfoStateHolder(
     private val _state = MutableStateFlow(RemoteResourcesInfoUiState())
     val state: StateFlow<RemoteResourcesInfoUiState> = _state.asStateFlow()
 
-    // Written by the baseUrlChanges collector and read by refresh coroutines, both on the IO pool.
-    @Volatile
+    // All state transitions (fetch guard, publish, base URL reset, rerun bookkeeping) are serialized
+    // by this mutex; the network fetch itself runs outside it. Without it, a refresh racing the
+    // collector's reset could interleave and leave isFetching stuck on true with nothing running.
+    // rerunPending and baseUrlGeneration are only touched while holding the lock.
+    private val mutex = Mutex()
     private var rerunPending = false
 
     // Bumped on every base URL change: a probe started against the previous URL must not publish its result.
-    @Volatile
     private var baseUrlGeneration = 0
 
     init {
@@ -45,38 +49,54 @@ class RemoteResourcesInfoStateHolder(
         refresh()
         scope.launch {
             baseUrlChanges.collect {
-                // Info probed against the previous URL would misreport the new one: drop it before re-probing.
-                baseUrlGeneration++
-                _state.value = RemoteResourcesInfoUiState(isFetching = _state.value.isFetching)
+                mutex.withLock {
+                    // Info probed against the previous URL would misreport the new one: drop it before re-probing.
+                    baseUrlGeneration++
+                    _state.value = RemoteResourcesInfoUiState(isFetching = _state.value.isFetching)
 
-                // A refresh in flight probes the previous URL; queue a rerun instead of
-                // dropping the change on the isFetching guard.
-                if (_state.value.isFetching) {
-                    rerunPending = true
-                } else {
-                    refresh()
+                    // A refresh in flight probes the previous URL; queue a rerun instead of
+                    // dropping the change on the isFetching guard.
+                    if (_state.value.isFetching) {
+                        rerunPending = true
+                    }
                 }
+                // While a fetch is in flight this is dropped by the guard and the queued
+                // rerunPending covers the change instead.
+                refresh()
             }
         }
     }
 
     fun refresh() {
-        if (_state.value.isFetching) return
+        scope.launch { startRefresh() }
+    }
 
-        _state.value = _state.value.copy(isFetching = true)
-        val generation = baseUrlGeneration
-        scope.launch {
-            var result: ArcaeaResourcesRemoteInfo? = null
-            var failureText: String? = null
-            try {
-                result = resourcesApiClient.fetchRemoteInfo()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                logger.e(e) { "Error refreshing remote resources info" }
-                failureText = throwableToErrorText(e)
-            }
+    private suspend fun startRefresh() {
+        // The generation is captured in the same critical section that raises the guard, so a base
+        // URL change racing in between still invalidates this probe.
+        val generation =
+            mutex.withLock {
+                if (_state.value.isFetching) {
+                    null
+                } else {
+                    _state.value = _state.value.copy(isFetching = true)
+                    baseUrlGeneration
+                }
+            } ?: return
 
+        var result: ArcaeaResourcesRemoteInfo? = null
+        var failureText: String? = null
+        try {
+            result = resourcesApiClient.fetchRemoteInfo()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            logger.e(e) { "Error refreshing remote resources info" }
+            failureText = throwableToErrorText(e)
+        }
+
+        var rerun = false
+        mutex.withLock {
             if (generation == baseUrlGeneration) {
                 _state.value =
                     if (result != null) {
@@ -92,9 +112,10 @@ class RemoteResourcesInfoStateHolder(
 
             if (rerunPending) {
                 rerunPending = false
-                refresh()
+                rerun = true
             }
         }
+        if (rerun) refresh()
     }
 
     companion object {

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolder.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolder.kt
@@ -1,0 +1,58 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+import co.touchlab.kermit.Logger
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+data class RemoteResourcesInfoUiState(
+    val isFetching: Boolean = false,
+    val info: ArcaeaResourcesRemoteInfo? = null,
+    /** Failure text of the latest refresh; null after a successful refresh. */
+    val errorText: String? = null,
+)
+
+class RemoteResourcesInfoStateHolder(
+    private val resourcesApiClient: ArcaeaResourcesApiClient,
+) {
+    private val logger = Logger.withTag(LOG_TAG)
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val _state = MutableStateFlow(RemoteResourcesInfoUiState())
+    val state: StateFlow<RemoteResourcesInfoUiState> = _state.asStateFlow()
+
+    init {
+        // fetch latest data once constructed
+        // this requires [RemoteResourcesInfoUiState.isFetching] defaulting to false,
+        // otherwise the guard below will block this request
+        refresh()
+    }
+
+    fun refresh() {
+        if (_state.value.isFetching) return
+
+        _state.value = _state.value.copy(isFetching = true)
+        scope.launch {
+            try {
+                val info = resourcesApiClient.fetchRemoteInfo()
+                _state.value = RemoteResourcesInfoUiState(isFetching = false, info = info)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                logger.e(e) { "Error refreshing remote resources info" }
+                // Keep the previously fetched info: a transient failure must not wipe known metadata.
+                _state.value = _state.value.copy(isFetching = false, errorText = throwableToErrorText(e))
+            }
+        }
+    }
+
+    companion object {
+        private const val LOG_TAG = "RemoteResourcesInfo"
+    }
+}

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolder.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolder.kt
@@ -34,6 +34,10 @@ class RemoteResourcesInfoStateHolder(
     @Volatile
     private var rerunPending = false
 
+    // Bumped on every base URL change: a probe started against the previous URL must not publish its result.
+    @Volatile
+    private var baseUrlGeneration = 0
+
     init {
         // fetch latest data once constructed
         // this requires [RemoteResourcesInfoUiState.isFetching] defaulting to false,
@@ -41,6 +45,10 @@ class RemoteResourcesInfoStateHolder(
         refresh()
         scope.launch {
             baseUrlChanges.collect {
+                // Info probed against the previous URL would misreport the new one: drop it before re-probing.
+                baseUrlGeneration++
+                _state.value = RemoteResourcesInfoUiState(isFetching = _state.value.isFetching)
+
                 // A refresh in flight probes the previous URL; queue a rerun instead of
                 // dropping the change on the isFetching guard.
                 if (_state.value.isFetching) {
@@ -56,17 +64,32 @@ class RemoteResourcesInfoStateHolder(
         if (_state.value.isFetching) return
 
         _state.value = _state.value.copy(isFetching = true)
+        val generation = baseUrlGeneration
         scope.launch {
+            var result: ArcaeaResourcesRemoteInfo? = null
+            var failureText: String? = null
             try {
-                val info = resourcesApiClient.fetchRemoteInfo()
-                _state.value = RemoteResourcesInfoUiState(isFetching = false, info = info)
+                result = resourcesApiClient.fetchRemoteInfo()
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
                 logger.e(e) { "Error refreshing remote resources info" }
-                // Keep the previously fetched info: a transient failure must not wipe known metadata.
-                _state.value = _state.value.copy(isFetching = false, errorText = throwableToErrorText(e))
+                failureText = throwableToErrorText(e)
             }
+
+            if (generation == baseUrlGeneration) {
+                _state.value =
+                    if (result != null) {
+                        RemoteResourcesInfoUiState(isFetching = false, info = result)
+                    } else {
+                        // Keep the previously fetched info: a transient failure must not wipe known metadata.
+                        _state.value.copy(isFetching = false, errorText = failureText)
+                    }
+            } else {
+                // The collector already cleared the state; just release the guard so the rerun can start.
+                _state.value = _state.value.copy(isFetching = false)
+            }
+
             if (rerunPending) {
                 rerunPending = false
                 refresh()

--- a/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolder.kt
+++ b/shared/src/commonMain/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolder.kt
@@ -5,9 +5,11 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.launch
 
 data class RemoteResourcesInfoUiState(
@@ -19,19 +21,35 @@ data class RemoteResourcesInfoUiState(
 
 class RemoteResourcesInfoStateHolder(
     private val resourcesApiClient: ArcaeaResourcesApiClient,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO),
+    /** Emissions (e.g. base URL changes) trigger a refresh; the initial emission must be dropped upstream. */
+    baseUrlChanges: Flow<*> = emptyFlow<Nothing>(),
 ) {
     private val logger = Logger.withTag(LOG_TAG)
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-
     private val _state = MutableStateFlow(RemoteResourcesInfoUiState())
     val state: StateFlow<RemoteResourcesInfoUiState> = _state.asStateFlow()
+
+    // Written by the baseUrlChanges collector and read by refresh coroutines, both on the IO pool.
+    @Volatile
+    private var rerunPending = false
 
     init {
         // fetch latest data once constructed
         // this requires [RemoteResourcesInfoUiState.isFetching] defaulting to false,
         // otherwise the guard below will block this request
         refresh()
+        scope.launch {
+            baseUrlChanges.collect {
+                // A refresh in flight probes the previous URL; queue a rerun instead of
+                // dropping the change on the isFetching guard.
+                if (_state.value.isFetching) {
+                    rerunPending = true
+                } else {
+                    refresh()
+                }
+            }
+        }
     }
 
     fun refresh() {
@@ -48,6 +66,10 @@ class RemoteResourcesInfoStateHolder(
                 logger.e(e) { "Error refreshing remote resources info" }
                 // Keep the previously fetched info: a transient failure must not wipe known metadata.
                 _state.value = _state.value.copy(isFetching = false, errorText = throwableToErrorText(e))
+            }
+            if (rerunPending) {
+                rerunPending = false
+                refresh()
             }
         }
     }

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
@@ -142,25 +142,30 @@ class ArcaeaResourcesApiClientTest {
     @Test
     fun publishUrlNormalizesBaseUrl() =
         runTest {
-            val urls = mutableListOf<String>()
-            val client =
-                client("  https://example.test/publish/  ") { request ->
-                    urls.add(request.url.toString())
+            val engine =
+                MockEngine { request ->
                     if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
                 }
+            val httpClient = HttpClient(engine).also { httpClients.add(it) }
+            val client = ArcaeaResourcesApiClient(MutableStateFlow("  https://example.test/publish/  "), httpClient)
 
             client.fetchRemoteInfo()
 
+            // requestHistory is the engine's own thread-safe log: the four probes run concurrently,
+            // so collecting URLs from the handlers would race and their order is not a contract.
+            val urls = engine.requestHistory.map { it.url.toString() }
+            assertEquals("https://example.test/publish/index.json", urls.first())
             assertEquals(
-                listOf(
+                setOf(
                     "https://example.test/publish/index.json",
                     "https://example.test/publish/7.0.255/packlist",
                     "https://example.test/publish/7.0.255/songlist",
                     "https://example.test/publish/7.0.255/ci.db",
                     "https://example.test/publish/7.0.255/ih.db",
                 ),
-                urls,
+                urls.toSet(),
             )
+            assertEquals(5, urls.size)
         }
 
     @Test

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
@@ -329,4 +329,39 @@ class ArcaeaResourcesApiClientTest {
                 SystemFileSystem.delete(dir, mustExist = false)
             }
         }
+
+    @Test
+    fun fetchRemoteInfoRejectsFileWhenHeadReportsOversize() =
+        runTest {
+            // The HEAD response carries no body; the client must reject on the declared
+            // Content-Length alone, before any download is attempted.
+            val client =
+                client(maxResourceBytes = 1024) { request ->
+                    when {
+                        request.url.toString().endsWith("index.json") -> {
+                            respondOk(indexJson)
+                        }
+
+                        request.url.toString().endsWith("packlist") -> {
+                            respond("", HttpStatusCode.OK, headersOf(HttpHeaders.ContentLength, "2048"))
+                        }
+
+                        request.url.toString().endsWith("songlist") -> {
+                            respond("", HttpStatusCode.OK, headersOf(HttpHeaders.ContentLength, "1024"))
+                        }
+
+                        else -> {
+                            respondOk("")
+                        }
+                    }
+                }
+
+            val info = client.fetchRemoteInfo()
+
+            assertEquals(false, info.packlist.isAvailable)
+            assertContains(info.packlist.errorText!!, "exceeds")
+            // Content-Length exactly at the limit is still available.
+            assertEquals(true, info.songlist.isAvailable)
+            assertEquals(true, info.chartInfoDatabase.isAvailable)
+        }
 }

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
@@ -8,10 +8,13 @@ import io.ktor.client.engine.mock.respondError
 import io.ktor.client.engine.mock.respondOk
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.IOException
 import kotlinx.io.buffered
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
@@ -36,6 +39,7 @@ class ArcaeaResourcesApiClientTest {
 
     private fun client(
         baseUrl: String = "https://example.test/publish",
+        maxResourceBytes: Long = 20L * 1024 * 1024,
         handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
     ): ArcaeaResourcesApiClient {
         val httpClient = HttpClient(MockEngine { handler(it) })
@@ -43,6 +47,7 @@ class ArcaeaResourcesApiClientTest {
         return ArcaeaResourcesApiClient(
             baseUrlFlow = MutableStateFlow(baseUrl),
             httpClient = httpClient,
+            maxResourceBytes = maxResourceBytes,
         )
     }
 
@@ -260,6 +265,65 @@ class ArcaeaResourcesApiClientTest {
                 val actual = SystemFileSystem.source(dest).buffered().use { it.readByteArray() }
                 assertEquals(expected.size, actual.size)
                 assertTrue(expected.contentEquals(actual))
+            } finally {
+                SystemFileSystem.delete(dest, mustExist = false)
+                SystemFileSystem.delete(dir, mustExist = false)
+            }
+        }
+
+    @Test
+    fun publishTextRejectsOversizedDeclaredBody() =
+        runTest {
+            // The declared length must match the body, or ktor rejects the response itself before
+            // the client's own size check runs.
+            val oversized = ByteArray(2048) { 'x'.code.toByte() }
+            val client =
+                client(maxResourceBytes = 1024) { request ->
+                    when {
+                        request.url.toString().endsWith("index.json") -> respondOk(indexJson)
+                        else -> respond(oversized, HttpStatusCode.OK, headersOf(HttpHeaders.ContentLength, "2048"))
+                    }
+                }
+
+            val e = assertFailsWith<IOException> { client.packlist() }
+
+            assertContains(e.message!!, "exceeds")
+        }
+
+    @Test
+    fun publishTextRejectsOversizedStreamedBody() =
+        runTest {
+            // No Content-Length on the response: the streamed byte count is the bound.
+            val client =
+                client(maxResourceBytes = 1024) { request ->
+                    when {
+                        request.url.toString().endsWith("index.json") -> respondOk(indexJson)
+                        else -> respond(ByteArray(2048) { 'x'.code.toByte() })
+                    }
+                }
+
+            val e = assertFailsWith<IOException> { client.packlist() }
+
+            assertContains(e.message!!, "exceeds")
+        }
+
+    @Test
+    fun downloadRejectsOversizedBody() =
+        runTest {
+            val client =
+                client(maxResourceBytes = 1024) { request ->
+                    when {
+                        request.url.toString().endsWith("index.json") -> respondOk(indexJson)
+                        request.url.toString().endsWith("ci.db") -> respond(ByteArray(2048) { 'x'.code.toByte() })
+                        else -> respondError(HttpStatusCode.NotFound)
+                    }
+                }
+
+            val dir = Path(SystemTemporaryDirectory, "arcaea-resources-client-test-oversize")
+            val dest = Path(dir, "ci.db")
+            SystemFileSystem.createDirectories(dir)
+            try {
+                assertFailsWith<IOException> { client.downloadChartInfoDatabase(dest) }
             } finally {
                 SystemFileSystem.delete(dest, mustExist = false)
                 SystemFileSystem.delete(dir, mustExist = false)

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
@@ -3,18 +3,26 @@ package xyz.sevive.arcaeaoffline.core.api
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
 import io.ktor.client.engine.mock.respondError
 import io.ktor.client.engine.mock.respondOk
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import kotlinx.io.buffered
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
+import kotlinx.io.files.SystemTemporaryDirectory
+import kotlinx.io.readByteArray
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class ArcaeaResourcesApiClientTest {
@@ -49,7 +57,18 @@ class ArcaeaResourcesApiClientTest {
         runTest {
             val client =
                 client { request ->
-                    if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
+                    when {
+                        request.url.toString().endsWith("index.json") -> {
+                            assertEquals(HttpMethod.Get, request.method)
+                            respondOk(indexJson)
+                        }
+
+                        else -> {
+                            // Probes must stay HEAD: probing with GET would pull the whole file just to test existence.
+                            assertEquals(HttpMethod.Head, request.method)
+                            respondOk("")
+                        }
+                    }
                 }
 
             val info = client.fetchRemoteInfo()
@@ -166,4 +185,79 @@ class ArcaeaResourcesApiClientTest {
         assertEquals(expectedBuiltAt, parseBuiltAt("2026-09-06T23:46:11+00:00"))
         assertEquals(null, parseBuiltAt("not a date"))
     }
+
+    @Test
+    fun fetchRemoteInfoHandlesLatestMissingFromVersions() =
+        runTest {
+            val client =
+                client { request ->
+                    if (request.url.toString().endsWith("index.json")) {
+                        respondOk(
+                            """{"latest": "7.0.255", "versions": [{"version": "7.0.0", "built_at": "2026-01-01T00:00:00+00:00"}]}""",
+                        )
+                    } else {
+                        respondOk("")
+                    }
+                }
+
+            val info = client.fetchRemoteInfo()
+
+            for (file in listOf(info.packlist, info.songlist, info.chartInfoDatabase, info.imageHashesDatabase)) {
+                assertEquals("7.0.255", file.version)
+                assertEquals(null, file.builtAt)
+            }
+        }
+
+    @Test
+    fun fetchRemoteInfoPicksBuiltAtOfMatchingVersion() =
+        runTest {
+            val client =
+                client { request ->
+                    if (request.url.toString().endsWith("index.json")) {
+                        respondOk(
+                            """{"latest": "7.0.255", "versions": [""" +
+                                """{"version": "7.0.0", "built_at": "2026-01-01T00:00:00+00:00"}, """ +
+                                """{"version": "7.0.255", "built_at": "2026-09-06T23:46:11+00:00"}]}""",
+                        )
+                    } else {
+                        respondOk("")
+                    }
+                }
+
+            val info = client.fetchRemoteInfo()
+
+            for (file in listOf(info.packlist, info.songlist, info.chartInfoDatabase, info.imageHashesDatabase)) {
+                assertEquals("7.0.255", file.version)
+                assertEquals(expectedBuiltAt, file.builtAt)
+            }
+        }
+
+    @Test
+    fun downloadWritesChunkedBodyToFile() =
+        runTest {
+            // Two full download chunks plus a tail, to pin down the copy loop's boundaries.
+            val expected = ByteArray(2 * 64 * 1024 + 17) { (it % 251).toByte() }
+            val client =
+                client { request ->
+                    when {
+                        request.url.toString().endsWith("index.json") -> respondOk(indexJson)
+                        request.url.toString().endsWith("ci.db") -> respond(expected)
+                        else -> respondError(HttpStatusCode.NotFound)
+                    }
+                }
+
+            val dir = Path(SystemTemporaryDirectory, "arcaea-resources-client-test")
+            val dest = Path(dir, "ci.db")
+            SystemFileSystem.createDirectories(dir)
+            try {
+                client.downloadChartInfoDatabase(dest)
+
+                val actual = SystemFileSystem.source(dest).buffered().use { it.readByteArray() }
+                assertEquals(expected.size, actual.size)
+                assertTrue(expected.contentEquals(actual))
+            } finally {
+                SystemFileSystem.delete(dest, mustExist = false)
+                SystemFileSystem.delete(dir, mustExist = false)
+            }
+        }
 }

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesApiClientTest.kt
@@ -1,0 +1,169 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respondError
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.time.Instant
+
+class ArcaeaResourcesApiClientTest {
+    // Example index.json response (2026-09-07)
+    private val indexJson =
+        """{"latest": "7.0.255", "versions": [{"version": "7.0.255", "built_at": "2026-09-06T23:46:11+00:00"}]}"""
+
+    private val expectedBuiltAt = Instant.parse("2026-09-06T23:46:11+00:00").toEpochMilliseconds()
+
+    private val httpClients = mutableListOf<HttpClient>()
+
+    private fun client(
+        baseUrl: String = "https://example.test/publish",
+        handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
+    ): ArcaeaResourcesApiClient {
+        val httpClient = HttpClient(MockEngine { handler(it) })
+        httpClients.add(httpClient)
+        return ArcaeaResourcesApiClient(
+            baseUrlFlow = MutableStateFlow(baseUrl),
+            httpClient = httpClient,
+        )
+    }
+
+    @AfterTest
+    fun tearDown() {
+        httpClients.forEach { it.close() }
+        httpClients.clear()
+    }
+
+    @Test
+    fun fetchRemoteInfoReturnsAllFilesWhenAvailable() =
+        runTest {
+            val client =
+                client { request ->
+                    if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
+                }
+
+            val info = client.fetchRemoteInfo()
+
+            for (file in listOf(info.packlist, info.songlist, info.chartInfoDatabase, info.imageHashesDatabase)) {
+                assertEquals(true, file.isAvailable, file.errorText)
+                assertEquals("7.0.255", file.version)
+                assertEquals(expectedBuiltAt, file.builtAt)
+                assertEquals(null, file.errorText)
+            }
+        }
+
+    @Test
+    fun fetchRemoteInfoReportsIndexFailureOnEveryFile() =
+        runTest {
+            val client = client { throw java.io.IOException("network down") }
+
+            val info = client.fetchRemoteInfo()
+
+            for (file in listOf(info.packlist, info.songlist, info.chartInfoDatabase, info.imageHashesDatabase)) {
+                assertEquals(false, file.isAvailable)
+                assertEquals(null, file.version)
+                assertEquals(null, file.builtAt)
+                assertEquals(throwableToErrorText(java.io.IOException("network down")), file.errorText)
+            }
+        }
+
+    @Test
+    fun fetchRemoteInfoIsolatesSingleFileFailure() =
+        runTest {
+            val client =
+                client { request ->
+                    when {
+                        request.url.toString().endsWith("index.json") -> respondOk(indexJson)
+                        request.url.toString().endsWith("packlist") -> respondError(HttpStatusCode.NotFound)
+                        request.url.toString().endsWith("songlist") -> throw java.io.IOException("timeout")
+                        else -> respondOk("")
+                    }
+                }
+
+            val info = client.fetchRemoteInfo()
+
+            assertEquals(false, info.packlist.isAvailable)
+            assertEquals("404", info.packlist.errorText)
+            assertEquals(false, info.songlist.isAvailable)
+            assertContains(info.songlist.errorText!!, "IOException")
+            for (file in listOf(info.chartInfoDatabase, info.imageHashesDatabase)) {
+                assertEquals(true, file.isAvailable)
+            }
+        }
+
+    @Test
+    fun fetchRemoteInfoHandlesMissingBuiltAt() =
+        runTest {
+            val client =
+                client { request ->
+                    if (request.url.toString().endsWith("index.json")) {
+                        respondOk("""{"latest": "7.0.255", "versions": [{"version": "7.0.255"}]}""")
+                    } else {
+                        respondOk("")
+                    }
+                }
+
+            val info = client.fetchRemoteInfo()
+
+            for (file in listOf(info.packlist, info.songlist, info.chartInfoDatabase, info.imageHashesDatabase)) {
+                assertEquals(null, file.builtAt)
+            }
+        }
+
+    @Test
+    fun publishUrlNormalizesBaseUrl() =
+        runTest {
+            val urls = mutableListOf<String>()
+            val client =
+                client("  https://example.test/publish/  ") { request ->
+                    urls.add(request.url.toString())
+                    if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
+                }
+
+            client.fetchRemoteInfo()
+
+            assertEquals(
+                listOf(
+                    "https://example.test/publish/index.json",
+                    "https://example.test/publish/7.0.255/packlist",
+                    "https://example.test/publish/7.0.255/songlist",
+                    "https://example.test/publish/7.0.255/ci.db",
+                    "https://example.test/publish/7.0.255/ih.db",
+                ),
+                urls,
+            )
+        }
+
+    @Test
+    fun publishTextThrowsApiExceptionOnHttpError() =
+        runTest {
+            val client =
+                client { request ->
+                    when {
+                        request.url.toString().endsWith("index.json") -> respondOk(indexJson)
+                        request.url.toString().endsWith("packlist") -> respondError(HttpStatusCode.InternalServerError)
+                        else -> respondOk("")
+                    }
+                }
+
+            val e = assertFailsWith<ArcaeaResourcesApiException> { client.packlist() }
+
+            assertContains(e.message!!, "500")
+        }
+
+    @Test
+    fun parseBuiltAtAcceptsIsoAndRejectsGarbage() {
+        assertEquals(expectedBuiltAt, parseBuiltAt("2026-09-06T23:46:11+00:00"))
+        assertEquals(null, parseBuiltAt("not a date"))
+    }
+}

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesIndexParsingTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/ArcaeaResourcesIndexParsingTest.kt
@@ -1,0 +1,37 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ArcaeaResourcesIndexParsingTest {
+    // Example response (2026-09-07)
+    private val sampleJson =
+        """
+        {
+          "latest": "7.0.255",
+          "versions": [
+            {
+              "version": "7.0.255",
+              "built_at": "2026-09-06T23:46:11+00:00"
+            }
+          ]
+        }
+        """.trimIndent()
+
+    @Test
+    fun parseRemoteIndexParsesLatestAndBuiltAt() {
+        val dto = parseRemoteIndex(sampleJson)
+
+        assertEquals("7.0.255", dto.latest)
+        assertEquals(1, dto.versions.size)
+        assertEquals("7.0.255", dto.versions[0].version)
+        assertEquals("2026-09-06T23:46:11+00:00", dto.versions[0].builtAt)
+    }
+
+    @Test
+    fun parseRemoteIndexIgnoresUnknownKeys() {
+        val dto = parseRemoteIndex("""{"latest": "1.0.0", "future_field": 123}""")
+
+        assertEquals("1.0.0", dto.latest)
+    }
+}

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolderTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolderTest.kt
@@ -136,11 +136,13 @@ class RemoteResourcesInfoStateHolderTest {
             runCurrent()
             assertTrue(holder.state.value.isFetching)
 
+            // Two overlapping calls: both must be dropped by the guard, not just the first one.
+            holder.refresh()
             holder.refresh()
             gate.complete(Unit)
             advanceUntilIdle()
 
-            assertEquals(1, indexRequests, "a refresh call during an in-flight refresh must be dropped")
+            assertEquals(1, indexRequests, "refresh calls during an in-flight refresh must be dropped")
             assertFalse(holder.state.value.isFetching)
         }
 

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolderTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolderTest.kt
@@ -1,0 +1,116 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respondOk
+import io.ktor.client.request.HttpRequestData
+import io.ktor.client.request.HttpResponseData
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class RemoteResourcesInfoStateHolderTest {
+    // Example index.json response (2026-09-07)
+    private val indexJson =
+        """{"latest": "7.0.255", "versions": [{"version": "7.0.255", "built_at": "2026-09-06T23:46:11+00:00"}]}"""
+
+    // The ktor engine executes requests on its own dispatcher; both fields are
+    // written by the test thread and read by the engine thread.
+    @Volatile
+    private var handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData =
+        { respondOk("") }
+
+    @Volatile
+    private var fail = false
+
+    private val clients = mutableListOf<HttpClient>()
+
+    private fun client() =
+        ArcaeaResourcesApiClient(
+            baseUrlFlow = MutableStateFlow("https://example.test/publish"),
+            httpClient = HttpClient(MockEngine { handler(it) }).also { clients.add(it) },
+        )
+
+    @AfterTest
+    fun tearDown() {
+        clients.forEach { it.close() }
+        clients.clear()
+    }
+
+    @Test
+    fun successfulInitRefreshPopulatesState() =
+        runTest {
+            handler = { request ->
+                if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
+            }
+            val holder = RemoteResourcesInfoStateHolder(client())
+
+            // The refresh runs on the engine's dispatcher; wait for the outcome instead of asserting timing.
+            val state = holder.state.first { it.info != null || it.errorText != null }
+
+            assertFalse(state.isFetching)
+            assertNull(state.errorText)
+            assertNotNull(state.info)
+        }
+
+    @Test
+    fun refreshWithFailingIndexSurfacesPerFileErrorText() =
+        runTest {
+            handler = { request ->
+                if (fail) throw java.io.IOException("network down")
+                if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
+            }
+            val holder = RemoteResourcesInfoStateHolder(client())
+            holder.state.first { it.info != null }
+
+            fail = true
+            holder.refresh()
+            val state = holder.state.first { it.info?.packlist?.errorText != null }
+
+            assertFalse(state.isFetching)
+            // An index failure degrades the info (per-file error text) instead of throwing to the holder.
+            assertEquals(false, state.info!!.packlist.isAvailable)
+            assertTrue(
+                state.info
+                    .packlist.errorText!!
+                    .contains("IOException"),
+            )
+            assertEquals(null, state.errorText)
+        }
+
+    @Test
+    fun refreshWhileFetchingIsIgnored() =
+        runTest {
+            val gate = CompletableDeferred<Unit>()
+            val indexRequests = AtomicInteger()
+            handler = { request ->
+                if (request.url.toString().endsWith("index.json")) {
+                    indexRequests.incrementAndGet()
+                    gate.await()
+                    respondOk(indexJson)
+                } else {
+                    respondOk("")
+                }
+            }
+            val holder = RemoteResourcesInfoStateHolder(client())
+            // Wait until the init refresh is provably in flight.
+            holder.state.first { it.isFetching }
+
+            holder.refresh()
+            gate.complete(Unit)
+            val state = holder.state.first { it.info != null }
+
+            assertEquals(1, indexRequests.get(), "a refresh call during an in-flight refresh must be dropped")
+            assertFalse(state.isFetching)
+        }
+}

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolderTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolderTest.kt
@@ -2,15 +2,22 @@ package xyz.sevive.arcaeaoffline.core.api
 
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
 import io.ktor.client.engine.mock.MockRequestHandleScope
 import io.ktor.client.engine.mock.respondOk
 import io.ktor.client.request.HttpRequestData
 import io.ktor.client.request.HttpResponseData
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import java.util.concurrent.atomic.AtomicInteger
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -19,44 +26,62 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class RemoteResourcesInfoStateHolderTest {
     // Example index.json response (2026-09-07)
     private val indexJson =
         """{"latest": "7.0.255", "versions": [{"version": "7.0.255", "built_at": "2026-09-06T23:46:11+00:00"}]}"""
 
-    // The ktor engine executes requests on its own dispatcher; both fields are
-    // written by the test thread and read by the engine thread.
-    @Volatile
     private var handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData =
         { respondOk("") }
 
-    @Volatile
-    private var fail = false
-
     private val clients = mutableListOf<HttpClient>()
+    private val scopeJobs = mutableListOf<Job>()
+
+    // The engine defaults to a real IO dispatcher; pin it to the test scheduler so the tests stay
+    // single-threaded and deterministic.
+    private val testDispatcher = StandardTestDispatcher()
+
+    private fun engine() =
+        MockEngine(
+            MockEngineConfig().apply {
+                dispatcher = testDispatcher
+                addHandler { request -> handler(request) }
+            },
+        )
 
     private fun client() =
         ArcaeaResourcesApiClient(
             baseUrlFlow = MutableStateFlow("https://example.test/publish"),
-            httpClient = HttpClient(MockEngine { handler(it) }).also { clients.add(it) },
+            httpClient = HttpClient(engine()).also { clients.add(it) },
         )
+
+    // A plain scope, not backgroundScope: advanceUntilIdle stops while only background-scope tasks
+    // remain, which would leave the init refresh unfinished.
+    private fun holderScope(): CoroutineScope {
+        val job = SupervisorJob()
+        scopeJobs += job
+        return CoroutineScope(job + testDispatcher)
+    }
 
     @AfterTest
     fun tearDown() {
         clients.forEach { it.close() }
         clients.clear()
+        scopeJobs.forEach { it.cancel() }
+        scopeJobs.clear()
     }
 
     @Test
     fun successfulInitRefreshPopulatesState() =
-        runTest {
+        runTest(testDispatcher) {
             handler = { request ->
                 if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
             }
-            val holder = RemoteResourcesInfoStateHolder(client())
+            val holder = RemoteResourcesInfoStateHolder(client(), holderScope())
+            advanceUntilIdle()
 
-            // The refresh runs on the engine's dispatcher; wait for the outcome instead of asserting timing.
-            val state = holder.state.first { it.info != null || it.errorText != null }
+            val state = holder.state.value
 
             assertFalse(state.isFetching)
             assertNull(state.errorText)
@@ -65,52 +90,133 @@ class RemoteResourcesInfoStateHolderTest {
 
     @Test
     fun refreshWithFailingIndexSurfacesPerFileErrorText() =
-        runTest {
+        runTest(testDispatcher) {
+            var fail = false
             handler = { request ->
                 if (fail) throw java.io.IOException("network down")
                 if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
             }
-            val holder = RemoteResourcesInfoStateHolder(client())
-            holder.state.first { it.info != null }
+            val holder = RemoteResourcesInfoStateHolder(client(), holderScope())
+            advanceUntilIdle()
+            assertNotNull(holder.state.value.info)
 
             fail = true
             holder.refresh()
-            val state = holder.state.first { it.info?.packlist?.errorText != null }
+            advanceUntilIdle()
+            val state = holder.state.value
 
             assertFalse(state.isFetching)
             // An index failure degrades the info (per-file error text) instead of throwing to the holder.
-            assertEquals(false, state.info!!.packlist.isAvailable)
+            assertFalse(state.info!!.packlist.isAvailable)
             assertTrue(
                 state.info
                     .packlist.errorText!!
                     .contains("IOException"),
             )
-            assertEquals(null, state.errorText)
+            assertNull(state.errorText)
         }
 
     @Test
     fun refreshWhileFetchingIsIgnored() =
-        runTest {
+        runTest(testDispatcher) {
             val gate = CompletableDeferred<Unit>()
-            val indexRequests = AtomicInteger()
+            var indexRequests = 0
             handler = { request ->
                 if (request.url.toString().endsWith("index.json")) {
-                    indexRequests.incrementAndGet()
+                    indexRequests++
                     gate.await()
                     respondOk(indexJson)
                 } else {
                     respondOk("")
                 }
             }
-            val holder = RemoteResourcesInfoStateHolder(client())
-            // Wait until the init refresh is provably in flight.
-            holder.state.first { it.isFetching }
+            val holder = RemoteResourcesInfoStateHolder(client(), holderScope())
+            // Run until the init refresh suspends on the gate.
+            runCurrent()
+            assertTrue(holder.state.value.isFetching)
 
             holder.refresh()
             gate.complete(Unit)
-            val state = holder.state.first { it.info != null }
+            advanceUntilIdle()
 
-            assertEquals(1, indexRequests.get(), "a refresh call during an in-flight refresh must be dropped")
+            assertEquals(1, indexRequests, "a refresh call during an in-flight refresh must be dropped")
+            assertFalse(holder.state.value.isFetching)
+        }
+
+    @Test
+    fun refreshFailureKeepsPreviousInfoAndSetsErrorText() =
+        runTest(testDispatcher) {
+            var fail = false
+            val flakyClient =
+                object : ArcaeaResourcesApiClient(
+                    baseUrlFlow = MutableStateFlow("https://example.test/publish"),
+                    httpClient = HttpClient(engine()).also { clients.add(it) },
+                ) {
+                    override suspend fun fetchRemoteInfo(): ArcaeaResourcesRemoteInfo {
+                        if (fail) throw java.io.IOException("boom")
+                        return ArcaeaResourcesRemoteInfo(
+                            packlist = ArcaeaResourcesRemoteFileInfo(true, "7.0.255", 1L, null),
+                            songlist = ArcaeaResourcesRemoteFileInfo(true, "7.0.255", 1L, null),
+                            chartInfoDatabase = ArcaeaResourcesRemoteFileInfo(true, "7.0.255", 1L, null),
+                            imageHashesDatabase = ArcaeaResourcesRemoteFileInfo(true, "7.0.255", 1L, null),
+                        )
+                    }
+                }
+            val holder = RemoteResourcesInfoStateHolder(flakyClient, holderScope())
+            advanceUntilIdle()
+            val knownInfo = assertNotNull(holder.state.value.info)
+
+            fail = true
+            holder.refresh()
+            advanceUntilIdle()
+            val state = holder.state.value
+
             assertFalse(state.isFetching)
+            assertEquals(knownInfo, state.info)
+            assertTrue(state.errorText!!.contains("IOException"))
+        }
+
+    @Test
+    fun baseUrlChangeDuringRefreshRerunsAfterSettle() =
+        runTest(testDispatcher) {
+            val gate = CompletableDeferred<Unit>()
+            val urls = mutableListOf<String>()
+            val urlFlow = MutableStateFlow("https://example.test/publish")
+            val changingClient =
+                ArcaeaResourcesApiClient(
+                    baseUrlFlow = urlFlow,
+                    httpClient = HttpClient(engine()).also { clients.add(it) },
+                )
+            handler = { request ->
+                urls.add(request.url.toString())
+                if (request.url.toString().endsWith("index.json")) {
+                    gate.await()
+                    respondOk(indexJson)
+                } else {
+                    respondOk("")
+                }
+            }
+            // The flow's initial emission must be dropped upstream; start reacting from the first change.
+            val holder =
+                RemoteResourcesInfoStateHolder(
+                    changingClient,
+                    holderScope(),
+                    baseUrlChanges = urlFlow.drop(1),
+                )
+            // Run until the init refresh suspends on the gate.
+            runCurrent()
+            assertTrue(holder.state.value.isFetching)
+
+            urlFlow.value = "https://other.example/publish"
+            gate.complete(Unit)
+            advanceUntilIdle()
+
+            // The first refresh probed the old URL; the queued rerun must have probed the new one.
+            val indexUrls = urls.filter { it.endsWith("index.json") }
+            assertEquals(
+                listOf("https://example.test/publish/index.json", "https://other.example/publish/index.json"),
+                indexUrls,
+            )
+            assertFalse(holder.state.value.isFetching)
         }
 }

--- a/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolderTest.kt
+++ b/shared/src/commonTest/kotlin/xyz/sevive/arcaeaoffline/core/api/RemoteResourcesInfoStateHolderTest.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -50,9 +51,9 @@ class RemoteResourcesInfoStateHolderTest {
             },
         )
 
-    private fun client() =
+    private fun client(baseUrlFlow: Flow<String> = MutableStateFlow("https://example.test/publish")) =
         ArcaeaResourcesApiClient(
-            baseUrlFlow = MutableStateFlow("https://example.test/publish"),
+            baseUrlFlow = baseUrlFlow,
             httpClient = HttpClient(engine()).also { clients.add(it) },
         )
 
@@ -218,5 +219,34 @@ class RemoteResourcesInfoStateHolderTest {
                 indexUrls,
             )
             assertFalse(holder.state.value.isFetching)
+        }
+
+    @Test
+    fun baseUrlChangeClearsInfoWhenReprobeFails() =
+        runTest(testDispatcher) {
+            val urlFlow = MutableStateFlow("https://example.test/publish")
+            handler = { request ->
+                if (request.url.toString().contains("other.example")) throw java.io.IOException("new host down")
+                if (request.url.toString().endsWith("index.json")) respondOk(indexJson) else respondOk("")
+            }
+            val holder =
+                RemoteResourcesInfoStateHolder(
+                    client(urlFlow),
+                    holderScope(),
+                    baseUrlChanges = urlFlow.drop(1),
+                )
+            advanceUntilIdle()
+            assertNotNull(holder.state.value.info)
+
+            urlFlow.value = "https://other.example/publish"
+            advanceUntilIdle()
+            val state = holder.state.value
+
+            // The info object must describe the new URL: no version/built_at carried over from the old one.
+            val info = assertNotNull(state.info)
+            assertNull(info.packlist.version)
+            assertFalse(info.packlist.isAvailable)
+            assertTrue(info.packlist.errorText!!.contains("IOException"))
+            assertFalse(state.isFetching)
         }
 }

--- a/shared/src/jvmMain/kotlin/xyz/sevive/arcaeaoffline/core/api/PlatformHttpClient.jvm.kt
+++ b/shared/src/jvmMain/kotlin/xyz/sevive/arcaeaoffline/core/api/PlatformHttpClient.jvm.kt
@@ -1,0 +1,9 @@
+package xyz.sevive.arcaeaoffline.core.api
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.cio.CIO
+
+actual fun platformHttpClient(): HttpClient =
+    HttpClient(CIO) {
+        resourcesApiTimeouts()
+    }


### PR DESCRIPTION
## Summary

Adds the ability to download packlist, songlist and the chart info database from the publish API (Database Manage), and the image hashes database from the network (OCR Dependencies).

## Changes

- `shared/core/api`: Ktor-based `ArcaeaResourcesApiClient` (index.json fetch, HEAD probes, streamed downloads) and `RemoteResourcesInfoStateHolder`; per-platform engines (OkHttp / CIO) with shared timeout bounds sized for the largest published file (~1MB)
- Database Manage: download section with a remote status panel (version, built_at, per-file error text) and manual refresh
- OCR Dependencies: ih.db download validated the same way as manual import, then swapped into place via staging file + atomic move so an interrupted copy cannot destroy the current database
- Settings: configurable resources API base URL with validation and reset
- ImportTaskQueue extracted from DatabaseManageViewModel; download failures are logged under per-resource tags instead of the queue's raw fallback

## Notes

- Base URL changes trigger an automatic re-probe; download items are disabled while remote status is unknown
- Manual ih.db import now also uses the staged atomic-move swap
- Unit tests over MockEngine cover the client, failure isolation and the state holder
